### PR TITLE
BHoM_UI - Issue 50 - make sure the explode component don't update on empty input

### DIFF
--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -158,9 +158,17 @@ namespace BH.UI.Components
 
         public bool CollectOutputTypes(List<object> objects)
         {
-            // Collect the properties types and names
+            // Do not update if the list of input is empty
+            if (objects.Count == 0)
+                return false;
+
+            // Group the objects by type
             Dictionary<string, Type> properties = new Dictionary<string, Type>();
             var groups = objects.Where(x => x != null).GroupBy(x => x.GetType());
+            if (groups.Count() == 0)
+                return false;
+
+            // Collect the properties types and names
             foreach (var group in groups)
             {
                 if (typeof(IDictionary).IsAssignableFrom(group.Key))


### PR DESCRIPTION
Fixes #50.

You can try the file provide by Rob on this issue: https://github.com/BHoM/Grasshopper_Toolkit/issues/302
Just add a property to the CustomObject and the Explode should just turn orange instead of messing things up.