### PR TITLE
BHoM_UI - Provide support for menus other than WinForm and WPF

### DIFF
--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Global\SearchMenu_WinForm.cs" />
     <Compile Include="Global\SearchMenu_Wpf.cs" />
     <Compile Include="Templates\DataAccessor.cs" />
+    <Compile Include="Templates\ISelectorMenu.cs" />
     <Compile Include="Templates\ISelector.cs" />
     <Compile Include="Templates\MultiChoiceCaller.cs" />
     <Compile Include="Templates\Selector.cs" />

--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -155,6 +155,14 @@ namespace BH.UI.Templates
 
         /*************************************/
 
+        public virtual void AddToMenu(object menu)
+        {
+            if (Selector != null && SelectedItem == null)
+                Selector.AddToMenu(menu);
+        }
+
+        /*************************************/
+
         public virtual string Write()
         {
             try

--- a/BHoM_UI/Templates/ISelectorMenu.cs
+++ b/BHoM_UI/Templates/ISelectorMenu.cs
@@ -29,14 +29,10 @@ using System.Windows.Forms;
 
 namespace BH.UI.Templates
 {
-    public interface ISelector
+    public interface ISelectorMenu<T>
     {
-        event EventHandler<object> ItemSelected;
+        event EventHandler<T> ItemSelected;
 
-        void AddToMenu(ToolStripDropDown menu);
-
-        void AddToMenu(System.Windows.Controls.ContextMenu menu);
-
-        void AddToMenu(object menu);
+        void FillMenu(object menu);
     }
 }

--- a/BHoM_UI/Templates/Selector.cs
+++ b/BHoM_UI/Templates/Selector.cs
@@ -71,26 +71,36 @@ namespace BH.UI.Templates
 
         public void AddToMenu(ToolStripDropDown menu)
         {
-            if (m_Menu_WinForm == null)
-            {
-                m_Menu_WinForm = new SelectorMenu_WinForm<T>(m_ItemListStore[m_Key], m_ItemTreeStore[m_Key]);
-                m_Menu_WinForm.ItemSelected += M_Menu_ItemSelected;
-            }
+            if (m_SelectorMenu == null)
+                SetSelectorMenu(new SelectorMenu_WinForm<T>(m_ItemListStore[m_Key], m_ItemTreeStore[m_Key]));
 
-            m_Menu_WinForm.FillMenu(menu);
+            m_SelectorMenu.FillMenu(menu);
         }
 
         /*************************************/
 
         public void AddToMenu(System.Windows.Controls.ContextMenu menu)
         {
-            if (m_Menu_Wpf == null)
-            {
-                m_Menu_Wpf = new SelectorMenu_Wpf<T>(m_ItemListStore[m_Key], m_ItemTreeStore[m_Key]);
-                m_Menu_Wpf.ItemSelected += M_Menu_ItemSelected;
-            }
+            if (m_SelectorMenu == null)
+                SetSelectorMenu(new SelectorMenu_Wpf<T>(m_ItemListStore[m_Key], m_ItemTreeStore[m_Key]));
 
-            m_Menu_Wpf.FillMenu(menu);
+            m_SelectorMenu.FillMenu(menu);
+        }
+
+        /*************************************/
+
+        public void AddToMenu(object menu)
+        {
+            if (m_SelectorMenu != null)
+                m_SelectorMenu.FillMenu(menu);
+        }
+
+        /*************************************/
+
+        public void SetSelectorMenu<M>(SelectorMenu<T, M> selectorMenu)
+        {
+            m_SelectorMenu = selectorMenu;
+            m_SelectorMenu.ItemSelected += M_Menu_ItemSelected;
         }
 
 
@@ -108,10 +118,9 @@ namespace BH.UI.Templates
         /**** Private Fields              ****/
         /*************************************/
 
-        protected SelectorMenu_WinForm<T> m_Menu_WinForm = null;
-        protected SelectorMenu_Wpf<T> m_Menu_Wpf = null;
-
         protected string m_Key = "";
+        protected ISelectorMenu<T> m_SelectorMenu = null;
+
         protected static Dictionary<string, Tree<T>> m_ItemTreeStore = new Dictionary<string, Tree<T>>();
         protected static Dictionary<string, List<SearchItem>> m_ItemListStore = new Dictionary<string, List<SearchItem>>();
 

--- a/BHoM_UI/Templates/Selector.cs
+++ b/BHoM_UI/Templates/Selector.cs
@@ -99,8 +99,10 @@ namespace BH.UI.Templates
 
         public void SetSelectorMenu<M>(SelectorMenu<T, M> selectorMenu)
         {
+            selectorMenu.SetItems(m_ItemListStore[m_Key], m_ItemTreeStore[m_Key]);
+            selectorMenu.ItemSelected += M_Menu_ItemSelected;
+
             m_SelectorMenu = selectorMenu;
-            m_SelectorMenu.ItemSelected += M_Menu_ItemSelected;
         }
 
 

--- a/BHoM_UI/Templates/SelectorMenu.cs
+++ b/BHoM_UI/Templates/SelectorMenu.cs
@@ -68,6 +68,14 @@ namespace BH.UI.Templates
                 FillMenu((M)menu);
         }
 
+        /*************************************/
+
+        public void SetItems(List<SearchItem> itemList, Tree<T> itemTree)
+        {
+            m_ItemList = itemList;
+            m_ItemTree = itemTree;
+        }
+
 
         /*************************************/
         /**** Protected Methods           ****/

--- a/BHoM_UI/Templates/SelectorMenu.cs
+++ b/BHoM_UI/Templates/SelectorMenu.cs
@@ -30,7 +30,7 @@ using System.Threading.Tasks;
 
 namespace BH.UI.Templates
 {
-    public abstract class SelectorMenu<T, M>
+    public abstract class SelectorMenu<T, M> : ISelectorMenu<T>
     {
         /*************************************/
         /**** Public Events               ****/
@@ -58,6 +58,14 @@ namespace BH.UI.Templates
         {
             AddTree(menu, m_ItemTree);
             AddSearchBox(menu, m_ItemList);
+        }
+
+        /*************************************/
+
+        public void FillMenu(object menu)
+        {
+            if (menu is M)
+                FillMenu((M)menu);
         }
 
 

--- a/UI_PostBuild/Program.cs
+++ b/UI_PostBuild/Program.cs
@@ -101,7 +101,7 @@ namespace BHoM_UI
                                 
                         }
                     }
-                    catch (Exception e)
+                    catch
                     {
                         Console.WriteLine("Failed to copy sub-folders from " + path);
                     }


### PR DESCRIPTION
Fixes #54.

Should enable contextual menu support in Excel that apparently doesn't expose WinForm or WPF directly.

No change needed in Grasshopper or Dynamo. I have kept the methods supporting directly WinForm and WPF since they will be the most common ones anyway so the user still gets a type strong interface for the general cases.

The overall architecture is admittedly a bit convoluted but this is necessary to keep type strong support all the way (nicer for things like OrganiseItems methods) while having a asynchronous discovery of the types for components items (needs to be done ahead of time to prevent lag on opening context menu) and menu type (only known when actually opening the menu).  I'll eventually review it when I have more time but this is doing the job for now.

@epignatelli , @ZiolkowskiJakub , I have added you as reviewers just to make sure this doesn't impact things on your side (it shouldn't).