### PR TITLE
Issue 62 - Register correct type when exploding custom objects

### DIFF
--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -196,10 +196,10 @@ namespace BH.UI.Components
                 }
                 else if (group.Key == typeof(CustomObject))
                 {
-                    foreach (string propName in group.Cast<BHoMObject>().SelectMany(x => x.CustomData.Keys).Distinct())
+                    foreach (KeyValuePair<string, object> prop in group.Cast<BHoMObject>().SelectMany(x => x.CustomData).Distinct())
                     {
-                        if (!properties.ContainsKey(propName))
-                            properties[propName] = typeof(object);
+                        if (!properties.ContainsKey(prop.Key))
+                            properties[prop.Key] = prop.Value.GetType();
                     }
                 }
                 else


### PR DESCRIPTION
Fixes #63 
The property was registered with the general type `object`. For collection types, this caused the `DataAccessor` to ask for items rather lists.
This pr is storing the specific type.

You can test it together with https://github.com/BHoM/Grasshopper_Toolkit/pull/317 with this file:
https://burohappold.sharepoint.com/:u:/s/BHoM/EQ0-nZ87JpZNmelkOgfPQa8BfEWJaFM3-4pCC1TUVLgxPA?e=YweP8k
