### PR TITLE
BHoM_UI - Issue 68 - Explode fails for null in custom data or dictionary

### DIFF
--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -183,7 +183,7 @@ namespace BH.UI.Components
                         {
                             foreach (string key in dic.Keys.OfType<string>())
                             {
-                                if (!properties.ContainsKey(key))
+                                if (key != null & dic[key] != null &!properties.ContainsKey(key))
                                     properties[key] = dic[key].GetType();
                             }
                         }
@@ -198,7 +198,7 @@ namespace BH.UI.Components
                 {
                     foreach (KeyValuePair<string, object> prop in group.Cast<BHoMObject>().SelectMany(x => x.CustomData).Distinct())
                     {
-                        if (!properties.ContainsKey(prop.Key))
+                        if (!properties.ContainsKey(prop.Key) & prop.Value != null)
                             properties[prop.Key] = prop.Value.GetType();
                     }
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #68

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[ExplodeNullFail.zip](https://github.com/BHoM/BHoM_UI/files/2791529/ExplodeNullFail.zip) (Thanks @IsakNaslundBh)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->