### PR TITLE
BHoM_UI-Issue64-GetPropertyHandlingCollections

### DIFF
--- a/BHoM_UI/Components/Engine/GetProperty.cs
+++ b/BHoM_UI/Components/Engine/GetProperty.cs
@@ -21,15 +21,9 @@
  */
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.UI;
 using BH.UI.Templates;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BH.UI.Components
 {

--- a/BHoM_UI/Components/Engine/GetProperty.cs
+++ b/BHoM_UI/Components/Engine/GetProperty.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Reflection.Attributes;
+using BH.oM.UI;
 using BH.UI.Templates;
 using System;
 using System.Collections.Generic;
@@ -55,6 +56,17 @@ namespace BH.UI.Components
 
         public GetPropertyCaller() : base(typeof(GetPropertyCaller).GetMethod("GetProperty")) { }
 
+        /*************************************/
+        /**** Override Method             ****/
+        /*************************************/
+
+        public override object Run(object[] inputs)
+        {
+            object result = base.Run(inputs);
+            SetOutputTypes(result);
+            return result;
+        }
+
 
         /*************************************/
         /**** Public Method               ****/
@@ -65,6 +77,21 @@ namespace BH.UI.Components
         public static object GetProperty(object obj, string propName)
         {
             return Engine.Reflection.Query.PropertyValue(obj, propName);
+        }
+
+        /*************************************/
+
+        public bool SetOutputTypes(object result)
+        {
+            if (result == null)
+                return true;
+
+            if (OutputParams.Count < 1)
+                return true;
+
+            OutputParams[0].DataType = result.GetType();
+            CompileOutputSetters();
+            return true;
         }
 
         /*************************************/


### PR DESCRIPTION
Getting runtime type of the collected property value rather than declared type (GetProperty returns `object`)

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #64
The component was setting the output type base on the return type of the `GetPropertyValue` method, which is `object`. This creates problem when the runtime type is a `System.Collection`, preventing the component from unravelling it.
We're now getting the runtime type of the output. If `null` we're bypassing it and setting the declare type.
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/Es3A0aBdb11DibWCl17DCPwBgb0wmqEE9acA4vi50b_OLQ?e=Wnx240

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added:
- `public bool GetPropertyCaller.SetOutputTypes(object result)`
- `public override object GetPropertyCaller.Run(object[] inputs)`

### Additional comments
<!-- As required -->