### PR TITLE
BHoM_UI: Provide a way to update the InputParams in CustomObject

### DIFF
--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -96,9 +96,9 @@ namespace BH.UI.Components
 
         /*************************************/
 
-        public void AddInput(string name, Type type)
+        public void AddInput(int index, string name, Type type)
         {
-            InputParams.Add(GetParam(name, type));
+            InputParams.Insert(index, GetParam(name, type));
             CompileInputGetters();
         }
 

--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -123,7 +123,7 @@ namespace BH.UI.Components
         public bool UpdateInput(int index, string name, Type type = null)
         {
             if (InputParams.Count <= index)
-                return false;
+                return AddInput(index, name, type);
 
             if (name != null)
                 InputParams[index].Name = name;

--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -97,6 +97,40 @@ namespace BH.UI.Components
             CompileOutputSetters();
         }
 
+        /*************************************/
+
+        public void AddInput(string name, Type type)
+        {
+            InputParams.Add(GetParam(name, type));
+            CompileInputGetters();
+        }
+
+        /*************************************/
+
+        public bool RemoveInput(string name)
+        {
+            bool success = InputParams.RemoveAll(p => p.Name == name) > 0;
+            CompileInputGetters();
+            return success;
+        }
+
+        /*************************************/
+
+        public bool UpdateInput(int index, string name, Type type = null)
+        {
+            if (InputParams.Count <= index)
+                return false;
+
+            if (name != null)
+                InputParams[index].Name = name;
+
+            if (type != null)
+                InputParams[index].DataType = type;
+
+            CompileInputGetters();
+            return true;
+        }
+
 
         /*************************************/
         /**** Override Methods            ****/

--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -24,13 +24,10 @@ using BH.UI.Templates;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Reflection;
 using BH.oM.Base;
 using BH.oM.UI;
 using BH.Engine.Reflection;
-using System.ComponentModel;
 using BH.Engine.Serialiser;
 using System.Collections;
 

--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -96,16 +96,23 @@ namespace BH.UI.Components
 
         /*************************************/
 
-        public void AddInput(int index, string name, Type type)
+        public bool AddInput(int index, string name, Type type)
         {
+            if (name == null)
+                return false;
+
             InputParams.Insert(index, GetParam(name, type));
             CompileInputGetters();
+            return true;
         }
 
         /*************************************/
 
         public bool RemoveInput(string name)
         {
+            if (name == null)
+                return false;
+
             bool success = InputParams.RemoveAll(p => p.Name == name) > 0;
             CompileInputGetters();
             return success;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #80 
It supports the changes in the child PR: https://github.com/BHoM/Grasshopper_Toolkit/pull/329
It:
1. Adds support for modifying the `InputParams` in each implemented UI (e.g. Grasshopper).
2. Explicitly stores the `InputParams` and the `ForcedType` for (de)serialisation. It would be useful to serialise the entire `Caller` through json - @adecler is there a reason we're avoiding it beside storing the bare minimum? Is it to avoid breaking the (de)ser of the components in case we change something at a lower level?


<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added:
`public bool UpdateInput(int index, string name, Type type = null)`
`public bool RemoveInput(string name)`
`public bool UpdateInput(int index, string name, Type type = null)`
`public override string Write()`
`public override bool Read(string json)`


### Additional comments
<!-- As required -->