### PR TITLE
BHoM_UI-Issue77-NullCheckFix

### DIFF
--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -81,7 +81,7 @@ namespace BH.UI.Components
 
         public void SetInputs(List<string> names, List<Type> types = null)
         {
-            if (types != null & names.Count != types.Count)
+            if (types == null || names.Count != types.Count)
             {
                 Engine.Reflection.Compute.RecordWarning("The list length for names and types does not match. Inputs are set, but <types> variable will be ignored.");
                 InputParams = names.Select(x => GetParam(x)).ToList();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #77 
Fixing a null check. If `types` is `null` `types.Count` fails and crashes Dynamo.
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Just open Dynamo and add a property to CustomObject

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->