### PR TITLE
Remove IImmutable from the list of types in the CreateCustom component

### DIFF
--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -67,7 +67,7 @@ namespace BH.UI.Components
 
         public CreateCustomCaller() : base()
         {
-            SetPossibleItems(Engine.Reflection.Query.BHoMTypeList());
+            SetPossibleItems(Engine.Reflection.Query.BHoMTypeList().Where(t => t.GetInterface("IImmutable") == null));
 
             InputParams = new List<ParamInfo>();
             OutputParams = new List<ParamInfo>() { new ParamInfo { DataType = typeof(IObject), Kind = ParamKind.Output, Name = "object", Description = "New Object with properties set as per the inputs." } };

--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -67,7 +67,7 @@ namespace BH.UI.Components
 
         public CreateCustomCaller() : base()
         {
-            SetPossibleItems(Engine.Reflection.Query.BHoMTypeList().Where(t => t.GetInterface("IImmutable") == null));
+            SetPossibleItems(Engine.Reflection.Query.BHoMTypeList().Where(t => t?.GetInterface("IImmutable") == null));
 
             InputParams = new List<ParamInfo>();
             OutputParams = new List<ParamInfo>() { new ParamInfo { DataType = typeof(IObject), Kind = ParamKind.Output, Name = "object", Description = "New Object with properties set as per the inputs." } };


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #87 
<!-- Add short description of what has been fixed -->
The `CreateCustom` component now includes `IImmutable` classes in the types list.
The creation of these objects fails, and when it doesn't it returns an inconsistent object. 
They must be created via `Create` methods and `CreateCustom` should not include them in the list of possible types.

This pr is excluding them from the that list.

### Test files
<!-- Link to test files to validate the proposed changes -->
You can check that there are no `IImmutable` in the list when using a `CreateCustom`, right-clicking on it and looking for `BoundaryRepresentation` for example.
The test file is to ensure the rest works as before.
https://burohappold.sharepoint.com/:f:/s/BHoM/EmZKk1_KH09NuGEcr3KSvxIBgcw8reIJi3DuDZ3HBdlTSQ?e=4i7ZIQ

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->