### PR TITLE
Different UIs concur to fill the BHoM/Assembly folder

### DIFF
--- a/UI_PostBuild/Program.cs
+++ b/UI_PostBuild/Program.cs
@@ -130,9 +130,12 @@ namespace BHoM_UI
         private static void CleanDirectory(string folder)
         {
             DirectoryInfo di = new DirectoryInfo(folder);
-
+            List<string> skipThese = new List<string> { ".gha", ".xll", ".dna", ".Addin" };
             foreach (FileInfo file in di.GetFiles())
-                file.Delete();
+            {
+                if (!skipThese.Contains(file.Extension))
+                    file.Delete();
+            }
             foreach (DirectoryInfo dir in di.GetDirectories())
                 dir.Delete(true);
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #89 

<!-- Add short description of what has been fixed -->
When compiling a UI, the BHoM/Assemblies folder gets cleared. This means that if you build two UIs, you will get only the second one, since the first one gets wiped out.

I am adding a check for specific files, but this is not scalable. 
For the moment it is sufficient though, as we won't add a new UI every day.
 

### Test files
<!-- Link to test files to validate the proposed changes -->
No test file. To test, compile the Grasshopper_Toolkit first and then compile the Excel_Toolkit.
If the BHoM/Assemblies folder still contains the `.gha` file required by Grasshopper, the issue is considered fixed.