### PR TITLE
BHoM_UI: Issue72-ExplodeMultipleTypesOnSameParameter

### DIFF
--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -234,9 +234,11 @@ namespace BH.UI.Components
             OutputParams = new List<ParamInfo>() { };
             foreach (KeyValuePair<string, List<Type>> kvp in properties)
             {
+                IEnumerable<Type> uniqueTypes = kvp.Value.Distinct();
+                Type commonType = uniqueTypes.Count() > 1 ? typeof(object) : uniqueTypes.FirstOrDefault();
                 OutputParams.Add(new ParamInfo
                 {
-                    DataType = kvp.Value.Where(t => t != null).FirstOrDefault() ?? typeof(object),
+                    DataType = commonType ?? typeof(object),
                     Name = kvp.Key,
                     Kind = ParamKind.Output
                 });


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #72
<!-- Add short description of what has been fixed -->
When the same output in the explode component has objects of different types, it now crashes.
This pr sets the type to the generic `object`. It would be nice to have a way of getting the closest common type in the class hierarchy but I think it is not trivial. 
For the moment this provides a fix.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EfyyXnNHHAtNr-DRBKpqhekBmFR_uLV6JORfbNGIByJN8A?e=94bsyK
From @IsakNaslundBh 's example in the issue page

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->