### PR TITLE
BHoM_UI: Issue 92 - MenuRenameNonBHoMObjects

### DIFF
--- a/UI_Engine/Compute/Organise.cs
+++ b/UI_Engine/Compute/Organise.cs
@@ -55,7 +55,7 @@ namespace BH.Engine.UI
         public static Output<List<SearchItem>, Tree<MethodBase>> OrganiseMethods(this List<MethodBase> methods)
         {
             // Create method list
-            IEnumerable<string> paths = methods.Select(x => x.ToText(true));
+            IEnumerable<string> paths = methods.Select(x => x.ToText(true).Replace("Engine", "oM.NonBHoMObjects"));
             List<SearchItem> list = paths.Zip(methods, (k, v) => new SearchItem { Text = k, Item = v }).ToList();
 
             //Create method tree


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #92 
<!-- Add short description of what has been fixed -->
Removing the additional menu level that is now represented by `oM` and `Engine`.
The level collapsed and the entry `Engine` now is at the next menu level with the name `NonBHoMObjects`.

### Test files
<!-- Link to test files to validate the proposed changes -->
To test, compile the BHoM_UI and the Grasshopper_Toolkit. Add a `CreateObject` component and right click to see the changes to the menu.