### PR TITLE
BHoM_UI - Issue 81 - deprecated query not hidden

### DIFF
--- a/BHoM_UI/Components/Adapter/CreateQuery.cs
+++ b/BHoM_UI/Components/Adapter/CreateQuery.cs
@@ -57,7 +57,11 @@ namespace BH.UI.Components
         public CreateQueryCaller() : base()
         {
             Type queryType = typeof(BH.oM.DataManipulation.Queries.IQuery);
-            IEnumerable<MethodBase> methods  = BH.Engine.Reflection.Query.BHoMMethodList(true).Where(x => x.DeclaringType.Name == "Create" && queryType.IsAssignableFrom(x.ReturnType)).OrderBy(x => x.Name);
+            IEnumerable<MethodBase> methods  = BH.Engine.Reflection.Query.BHoMMethodList()
+                .Where(x => x.DeclaringType.Name == "Create"
+                && queryType.IsAssignableFrom(x.ReturnType)
+                && !x.IsDeprecated())
+                .OrderBy(x => x.Name);
             SetPossibleItems(methods);
         }
 

--- a/BHoM_UI/Components/Adapter/CreateQuery.cs
+++ b/BHoM_UI/Components/Adapter/CreateQuery.cs
@@ -57,7 +57,7 @@ namespace BH.UI.Components
         public CreateQueryCaller() : base()
         {
             Type queryType = typeof(BH.oM.DataManipulation.Queries.IQuery);
-            IEnumerable<MethodBase> methods  = BH.Engine.Reflection.Query.BHoMMethodList().Where(x => queryType.IsAssignableFrom(x.ReturnType)).OrderBy(x => x.Name);
+            IEnumerable<MethodBase> methods  = BH.Engine.Reflection.Query.BHoMMethodList(true).Where(x => x.DeclaringType.Name == "Create" && queryType.IsAssignableFrom(x.ReturnType)).OrderBy(x => x.Name);
             SetPossibleItems(methods);
         }
 

--- a/BHoM_UI/Global/SearchMenu.cs
+++ b/BHoM_UI/Global/SearchMenu.cs
@@ -111,7 +111,7 @@ namespace BH.UI.Global
                 if (string.IsNullOrEmpty(item.Text) && item.Item != null)
                     item.Text = ((MethodInfo)item.Item).ToText(true);
             }
-                
+
             // All methods for the BHoM Engine
             items.AddRange(Engine.Reflection.Query.BHoMMethodList().Where(x => !x.IsNotImplemented() && !x.IsDeprecated())
                                     .Select(x => new SearchItem { Item = x, CallerType = GetCallerType(x), Icon = GetIcon(x), Text = x.ToText(true) }));
@@ -121,8 +121,10 @@ namespace BH.UI.Global
                                     .Select(x => new SearchItem { Item = x, CallerType = typeof(CreateAdapterCaller), Icon = Properties.Resources.Adapter, Text = x.ToText(true) }));
 
             // All query constructors
+            // EP: Why are these not included in the above "All methods for the BHoM Engine"?
+            // EP: BHoMMethodList() should not contain constructors, but only public static methods
             Type queryType = typeof(BH.oM.DataManipulation.Queries.IQuery);
-            items.AddRange(Engine.Reflection.Query.BHoMMethodList().Where(x => queryType.IsAssignableFrom(x.ReturnType))
+            items.AddRange(Engine.Reflection.Query.BHoMMethodList(true).Where(x => queryType.IsAssignableFrom(x.ReturnType) && !x.IsNotImplemented() && !x.IsDeprecated())
                                     .Select(x => new SearchItem { Item = x, CallerType = typeof(CreateQueryCaller), Icon = Properties.Resources.QueryAdapter, Text = x.ToText(true) }));
 
             // All Types

--- a/BHoM_UI/Global/SearchMenu.cs
+++ b/BHoM_UI/Global/SearchMenu.cs
@@ -120,13 +120,6 @@ namespace BH.UI.Global
             items.AddRange(Engine.Reflection.Query.AdapterTypeList().Where(x => x.IsSubclassOf(typeof(BHoMAdapter))).SelectMany(x => x.GetConstructors())
                                     .Select(x => new SearchItem { Item = x, CallerType = typeof(CreateAdapterCaller), Icon = Properties.Resources.Adapter, Text = x.ToText(true) }));
 
-            // All query constructors
-            // EP: Why are these not included in the above "All methods for the BHoM Engine"?
-            // EP: BHoMMethodList() should not contain constructors, but only public static methods
-            Type queryType = typeof(BH.oM.DataManipulation.Queries.IQuery);
-            items.AddRange(Engine.Reflection.Query.BHoMMethodList(true).Where(x => queryType.IsAssignableFrom(x.ReturnType) && !x.IsNotImplemented() && !x.IsDeprecated())
-                                    .Select(x => new SearchItem { Item = x, CallerType = typeof(CreateQueryCaller), Icon = Properties.Resources.QueryAdapter, Text = x.ToText(true) }));
-
             // All Types
             items.AddRange(Engine.Reflection.Query.BHoMTypeList()
                                     .Select(x => new SearchItem { Item = x, CallerType = typeof(CreateTypeCaller), Icon = Properties.Resources.Type, Text = x.ToText(true) }));


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #81 
<!-- Add short description of what has been fixed -->
Two actions on this pr:
1. The global menu now shows methods that return an `IQuery` object just once. On the master branch, the method will appear twice: once with the `CreateQuery` icon, and once with the `CreateObject` icon.
2. The `CreateQuery` component now only exposes the methods from the `Create` class, as its nae would suggest. At the moment, any method that returns an `IQuery` (e.g. a `Modify`) will appear in the local menu.

@ZiolkowskiJakub I think the biggest effect of this pr is on the Revit_Toolkit, and also it creates a user case to see of the menu works.
Since we are using the `ReturnType` of the method to build the menu tree, all the Revit_Toolkit queries are now in the `DataManipulation` branch, and not in the Revit branch anymore. I don't find this very intuitive, but if we use the namespace of the `DeclaringType` as discriminator, we would have no way to know when an object is a `NonBHoMObject` (i.e. every `Create` method comes from the `Engine`).


### Test files
<!-- Link to test files to validate the proposed changes -->
To test, compile the BHoM_UI and the Grasshopper_Toolkit; open the Grasshopper and check both the global menu (CTRL+SHIFT+B) and the `CreateQuery` local menu.