### PR TITLE
Add keyboard control to SearchMenu

### DIFF
--- a/BHoM_UI/Global/SearchMenu_WinForm.cs
+++ b/BHoM_UI/Global/SearchMenu_WinForm.cs
@@ -91,7 +91,8 @@ namespace BH.UI.Global
                     Size = new System.Drawing.Size(m_MinWidth, 1),
                     TabIndex = 1,
                 };
-                m_Popup.Controls.Add(m_SearchResultPanel);  
+                m_Popup.Controls.Add(m_SearchResultPanel);
+                m_Popup.KeyDown += M_Popup_KeyDown;
             }
 
             // Finish the popup form
@@ -113,7 +114,42 @@ namespace BH.UI.Global
 
             TextBox_TextChanged(null, null);
 
+
             return true;
+        }
+
+        private void M_Popup_KeyDown(object sender, KeyEventArgs e)
+        {
+            e.SuppressKeyPress = true;
+            switch (e.KeyData)
+            {
+                case Keys.Up:
+                    if (--m_selected < 0)
+                        m_selected = m_SearchResultPanel.Controls.Count - 1;
+                    break;
+                case Keys.Down:
+                    m_selected = (m_selected + 1) % m_SearchResultPanel.Controls.Count;
+                    break;
+                case Keys.Enter:
+                    List<SearchItem> hits = PossibleItems.Hits(m_SearchTextBox.Text);
+                    if (m_selected < hits.Count)
+                    {
+                        m_Popup.Hide();
+                        NotifySelection(hits[m_selected]);
+                    }
+                    return;
+                case Keys.Escape:
+                    m_Popup.Hide();
+                    return;
+                default:
+                    e.SuppressKeyPress = false;
+                    return;
+            }
+            for (int i = 0; i < m_SearchResultPanel.Controls.Count; i++)
+            {
+                Control row = m_SearchResultPanel.Controls[i];
+                row.BackColor = (i == m_selected) ? System.Drawing.SystemColors.MenuHighlight : Color.Transparent;
+            }
         }
 
 
@@ -130,6 +166,7 @@ namespace BH.UI.Global
 
         private void TextBox_TextChanged(object sender, EventArgs e)
         {
+            m_selected = 0;
             List<SearchItem> hits = PossibleItems.Hits(m_SearchTextBox.Text);
 
             int yPos = 0;
@@ -141,7 +178,7 @@ namespace BH.UI.Global
                 Label label = new Label
                 {
                     Text = hit.Text,
-                    BackColor = Color.White,
+                    BackColor = Color.Transparent,
                     Cursor = Cursors.Hand,
                     TextAlign = ContentAlignment.MiddleLeft,
                 };
@@ -156,6 +193,7 @@ namespace BH.UI.Global
                 label.Location = new System.Drawing.Point(icon.Width + 5, 0);
 
                 Panel row = new Panel { Width = label.Width + icon.Width, Height = label.Height, Location = new System.Drawing.Point(0, yPos) };
+                if (i == m_selected) row.BackColor = System.Drawing.SystemColors.MenuHighlight;
                 row.Controls.Add(icon);
                 row.Controls.Add(label);
                 maxWidth = Math.Max(maxWidth, row.Width);
@@ -172,6 +210,7 @@ namespace BH.UI.Global
             }
             
             m_Popup.Width = maxWidth;
+            foreach (Control row in m_SearchResultPanel.Controls) row.Width = maxWidth;
             m_SearchResultPanel.Size = new System.Drawing.Size(maxWidth, yPos);
             m_Popup.Height = m_SearchResultPanel.Bottom + 10;
         }
@@ -187,6 +226,7 @@ namespace BH.UI.Global
         private static Form m_Popup = null;
         private static TextBox m_SearchTextBox = null;
         private static Panel m_SearchResultPanel = null;
+        private int m_selected;
 
         /*************************************/
     }

--- a/BHoM_UI/Global/SearchMenu_Wpf.cs
+++ b/BHoM_UI/Global/SearchMenu_Wpf.cs
@@ -81,6 +81,7 @@ namespace BH.UI.Global
                 grid.Children.Add(m_SearchResultGrid);
 
                 container.Children.Add(m_Popup);
+                m_Popup.KeyDown += M_Popup_KeyDown;
             }
 
             m_SearchTextBox.Text = "";
@@ -91,7 +92,41 @@ namespace BH.UI.Global
             return true;
         }
 
-        
+        private void M_Popup_KeyDown(object sender, KeyEventArgs e)
+        {
+            e.Handled = true;
+            switch (e.Key)
+            {
+                case Key.Up:
+                    if (--m_selected < 0)
+                        m_selected = m_hits - 1;
+                    break;
+                case Key.Down:
+                    m_selected = (m_selected + 1) % m_hits;
+                    break;
+                case Key.Enter:
+                    List<SearchItem> hits = PossibleItems.Hits(m_SearchTextBox.Text);
+                    m_Popup.IsOpen = false;
+                    if (m_selected < hits.Count)
+                    {
+                        NotifySelection(hits[m_selected]);
+                    }
+                    return;
+                case Key.Escape:
+                    m_Popup.IsOpen = false;
+                    return;
+                default:
+                    e.Handled = false;
+                    return;
+            }
+            foreach (Label element in m_SearchResultGrid.Children)
+            {
+                int i = Grid.GetRow(element);
+                element.Background = (i == m_selected) ? System.Windows.SystemColors.HighlightBrush : System.Windows.Media.Brushes.White;
+            }
+        }
+
+
         /*************************************/
         /**** Private Methods             ****/
         /*************************************/
@@ -121,6 +156,9 @@ namespace BH.UI.Global
         {
             List<SearchItem> hits = PossibleItems.Hits(m_SearchTextBox.Text);
 
+            m_selected = 0;
+            m_hits = hits.Count;
+
             m_SearchResultGrid.Children.Clear();
             m_SearchResultGrid.RowDefinitions.Clear();
 
@@ -146,6 +184,7 @@ namespace BH.UI.Global
                 m_SearchResultGrid.Children.Add(icon);
 
                 Label label = new Label { Content = hit.Text, Background = System.Windows.Media.Brushes.White };
+                if (i == m_selected) label.Background = System.Windows.SystemColors.HighlightBrush;
                 label.MouseUp += (a, b) =>
                 {
                     m_Popup.IsOpen = false;
@@ -194,6 +233,8 @@ namespace BH.UI.Global
         private static Grid m_SearchResultGrid = null;
 
         private static Dictionary<Bitmap, ImageSource> m_ImageSources = new Dictionary<Bitmap, ImageSource>();
+        private int m_selected;
+        private int m_hits;
 
         /*************************************/
     }

--- a/BHoM_UI/Global/SearchMenu_Wpf.cs
+++ b/BHoM_UI/Global/SearchMenu_Wpf.cs
@@ -81,7 +81,7 @@ namespace BH.UI.Global
                 grid.Children.Add(m_SearchResultGrid);
 
                 container.Children.Add(m_Popup);
-                m_Popup.KeyDown += M_Popup_KeyDown;
+                m_SearchTextBox.PreviewKeyDown += M_SearchTextBox_PreviewKeyDown; 
             }
 
             m_SearchTextBox.Text = "";
@@ -92,7 +92,7 @@ namespace BH.UI.Global
             return true;
         }
 
-        private void M_Popup_KeyDown(object sender, KeyEventArgs e)
+        private void M_SearchTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
         {
             e.Handled = true;
             switch (e.Key)
@@ -119,7 +119,7 @@ namespace BH.UI.Global
                     e.Handled = false;
                     return;
             }
-            foreach (Label element in m_SearchResultGrid.Children)
+            foreach (Label element in m_SearchResultGrid.Children.OfType<Label>())
             {
                 int i = Grid.GetRow(element);
                 element.Background = (i == m_selected) ? System.Windows.SystemColors.HighlightBrush : System.Windows.Media.Brushes.White;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #105 

<!-- Add short description of what has been fixed -->
Currently only adds functionality to WinForms search menu (Excel and Grasshopper). Unable to test with Dynamo because I can't open the GlobalSearch on Dynamo to do so. Have the change on that side too that I think should work but I can't verify it.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->