### PR TITLE
BHoM_UI for the Grasshopper_Toolkit - Issue 226 - Input arrays

### DIFF
--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -360,7 +360,17 @@ namespace BH.UI.Templates
         protected virtual Func<DataAccessor, object> CreateInputAccessor(Type dataType, int index)
         {
             UnderlyingType subType = dataType.UnderlyingType();
-            string methodName = (subType.Depth == 0) ? "GetDataItem" : (subType.Depth == 1) ? "GetDataList" : "GetDataTree";
+            string methodName;
+            if (subType.Depth == 0)
+                methodName = "GetDataItem";
+            else if (subType.Depth == 1)
+                if (dataType.IsArray)
+                    methodName = "GetDataArray";
+                else
+                    methodName = "GetDataList";
+            else
+                methodName = "GetDataTree";
+
             MethodInfo method = DataAccessor.GetType().GetMethod(methodName).MakeGenericMethod(subType.Type);
 
             ParameterExpression lambdaInput1 = Expression.Parameter(typeof(DataAccessor), "accessor");

--- a/BHoM_UI/Templates/DataAccessor.cs
+++ b/BHoM_UI/Templates/DataAccessor.cs
@@ -42,6 +42,10 @@ namespace BH.UI.Templates
 
         /*************************************/
 
+        public abstract T[] GetDataArray<T>(int index);
+
+        /*************************************/
+
         public abstract List<List<T>> GetDataTree<T>(int index);
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/Grasshopper_Toolkit/issues/226
<!-- Add short description of what has been fixed -->

### Test files
<!-- Link to test files to validate the proposed changes -->
Note that, even you need to use https://github.com/BHoM/BHoM_Engine/pull/1124 to be able to input arrays, although it does not represent a code-wise dependency.
https://burohappold.sharepoint.com/:f:/s/BHoM/EjmxIfvj4WNBvi9qWzVvunoBwjYJX03lohJTTu8WHAxAhA?e=JpiJCu

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Adds `public abstract T[] DataAccessor.GetDataArray<T>(int index);`

### Additional comments
<!-- As required -->
This pr is to support https://github.com/BHoM/Grasshopper_Toolkit/pull/389. It adds an array getter. The method is abstract so, it must be implemented.