### PR TITLE
Reduced nesting of menu for IRequests; removed post-build events

### DIFF
--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -182,7 +182,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\BHoM\Assemblies"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UI_Engine/Compute/Organise.cs
+++ b/UI_Engine/Compute/Organise.cs
@@ -64,12 +64,12 @@ namespace BH.Engine.UI
                     if (typeof(BH.oM.Data.Requests.IRequest).IsAssignableFrom(mInfo.ReturnType))
                     {
                         string pathString = m.ToText(true);
-                        pathString
+                        string modifiedString = pathString
                             .Replace("BH.oM.Data.", m.DeclaringType.FullName.Replace(m.DeclaringType.Name, ""))
                             .Replace("BH.Engine.Data.", m.DeclaringType.FullName.Replace(m.DeclaringType.Name, ""))
                             .Replace("BH.oM.", "")
                             .Replace("BH.Engine.", "");
-                        return pathString;
+                        return modifiedString;
                     }
 
                 }

--- a/UI_Engine/Compute/Organise.cs
+++ b/UI_Engine/Compute/Organise.cs
@@ -57,12 +57,21 @@ namespace BH.Engine.UI
             // Create method path list
             List<string> paths = methods.Select(m =>
             {
-                // Deal with nested FilterRequest
+                // Deal with nested IRequests in menu
                 var mInfo = m as MethodInfo;
                 if (mInfo != null)
                 {
-                    if (mInfo.ReturnType == typeof(BH.oM.Data.Requests.FilterRequest))
-                        return m.ToText(true).Replace("BH.oM.Data.", m.DeclaringType.FullName.Replace(m.DeclaringType.Name, ""));
+                    if (typeof(BH.oM.Data.Requests.IRequest).IsAssignableFrom(mInfo.ReturnType))
+                    {
+                        string pathString = m.ToText(true);
+                        pathString
+                            .Replace("BH.oM.Data.", m.DeclaringType.FullName.Replace(m.DeclaringType.Name, ""))
+                            .Replace("BH.Engine.Data.", m.DeclaringType.FullName.Replace(m.DeclaringType.Name, ""))
+                            .Replace("BH.oM.", "")
+                            .Replace("BH.Engine.", "");
+                        return pathString;
+                    }
+
                 }
 
                 return m.ToText(true).Replace("Engine", "oM.NonBHoMObjects");

--- a/UI_Engine/Compute/Organise.cs
+++ b/UI_Engine/Compute/Organise.cs
@@ -63,15 +63,8 @@ namespace BH.Engine.UI
                 {
                     if (typeof(BH.oM.Data.Requests.IRequest).IsAssignableFrom(mInfo.ReturnType))
                     {
-                        string pathString = m.ToText(true);
-                        string modifiedString = pathString
-                            .Replace("BH.oM.Data.", m.DeclaringType.FullName.Replace(m.DeclaringType.Name, ""))
-                            .Replace("BH.Engine.Data.", m.DeclaringType.FullName.Replace(m.DeclaringType.Name, ""))
-                            .Replace("BH.oM.", "")
-                            .Replace("BH.Engine.", "");
-                        return modifiedString;
+                        return m.ToText(true, useReturnTypeForCreate: false);
                     }
-
                 }
 
                 return m.ToText(true).Replace("Engine", "oM.NonBHoMObjects");

--- a/UI_Engine/Query/SearchItems.cs
+++ b/UI_Engine/Query/SearchItems.cs
@@ -42,10 +42,10 @@ namespace BH.Engine.UI
 
         /***************************************************/
 
-        public static IEnumerable<MethodBase> CreateItems()
+        public static IEnumerable<MethodBase> CreateItems() //object
         {
             return Engine.Reflection.Query.BHoMMethodList()
-                .Where(x => !x.IsNotImplemented() && !x.IsDeprecated() && x.DeclaringType.Name == "Create");
+                .Where(x => !x.IsNotImplemented() && !x.IsDeprecated() && x.DeclaringType.Name == "Create"); //concate BHoMTypeList
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
* https://github.com/BHoM/BHoM_Engine/pull/1164
* https://github.com/BHoM/Revit_Toolkit/pull/363 
     This PR is required in order to see the Revit Requests entries in the correct location.

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #121
Closes #103 

<!-- Add short description of what has been fixed -->
Groups together the Requests based on their namespace.


Just try to create a Request to test:
![image](https://user-images.githubusercontent.com/6352844/64261413-63b3a280-cf24-11e9-8d95-3c7fc675c4e0.png)

This has the effect that, e.g., if I create a FilterRequest in Revit_Toolkit it will go into the Revit submenu:

![image](https://user-images.githubusercontent.com/6352844/64261762-eb99ac80-cf24-11e9-8b1b-afdb9b16868f.png)

this avoids polluting the Data.FilterRequest menu with all the FilterRequests created in Revit [as was happening before](https://user-images.githubusercontent.com/6352844/64251946-9011f380-cf11-11e9-9e1d-ba52a1ea6b42.png).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
* Modified Requests menu, now it's less nested
* Removes post-build events (no longer necessary)