### PR TITLE
SearchMenu crashes the hosting UI if a method is defined in the `global` namespace

### DIFF
--- a/BHoM_UI/Templates/MethodCaller.cs
+++ b/BHoM_UI/Templates/MethodCaller.cs
@@ -149,7 +149,9 @@ namespace BH.UI.Templates
             {
                 Category = "Other";
                 string nameSpace = Method.DeclaringType.Namespace;
-                if (nameSpace != null && nameSpace.Length >= 2 && nameSpace.StartsWith("BH"))
+                if (nameSpace != null)
+                    Category = "Global";
+                if (nameSpace.Length >= 2 && nameSpace.StartsWith("BH"))
                     Category = nameSpace.Split('.')[1];
             }
         }

--- a/BHoM_UI/Templates/MethodCaller.cs
+++ b/BHoM_UI/Templates/MethodCaller.cs
@@ -147,11 +147,10 @@ namespace BH.UI.Templates
         {
             if (Method != null && Category == "Undefined")
             {
-                string[] nameSpace = Method.DeclaringType.Namespace.Split('.');
-                if (nameSpace.Length >= 2 && nameSpace[0] == "BH")
-                    Category = nameSpace[1];
-                else
-                    Category = "Other";
+                Category = "Other";
+                string nameSpace = Method.DeclaringType.Namespace;
+                if (nameSpace != null && nameSpace.Length >= 2 && nameSpace.StartsWith("BH"))
+                    Category = nameSpace.Split('.')[1];
             }
         }
 

--- a/UI_Engine/Query/Weight.cs
+++ b/UI_Engine/Query/Weight.cs
@@ -70,7 +70,7 @@ namespace BH.Engine.UI
                 else
                     name = declaringName;
 
-                foreach (string part in search.Where(p => method.DeclaringType.Namespace.ToLower().Contains(p)))
+                foreach (string part in search.Where(p => method.DeclaringType.Namespace != null && method.DeclaringType.Namespace.ToLower().Contains(p)))
                     weight += 2;
             }
             else if (item.Item is Type)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Closes #143 
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
You can use the procedure described in #143 to test the issue inside and outside this pr.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fix crash happening when methods lie in the `global` namespace.
- Methods in the global namespace have now assigned the `Global` category.
