### PR TITLE
Provide object descriptions if they're available on default create components

### DIFF
--- a/UI_Engine/Convert/ToBHoM.cs
+++ b/UI_Engine/Convert/ToBHoM.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.UI
             {
                 Name = property.Name,
                 DataType = property.PropertyType,
-                Description = property.PropertyType.IDescription(),
+                Description = property.IDescription(),
                 Kind = ParamKind.Input
             };
 


### PR DESCRIPTION
### Depends on
https://github.com/BHoM/BHoM_Engine/pull/1388


### Issues addressed by this PR
Fixes #172 


### Test files
Load any create component into a UI using the default create component rather than a coder-created one from an engine


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
@adecler it was found during the investigation of this issue that you added `.PropertyType` to the `property` variable in the file which is changed, so I'm not 100% that this is the right fix. It fixes the problem I am trying to solve, but am cautious that it might thus mess something else up. As such, I would like to wait for a review from you before merging to double check just in case :smile: I'm asking for a review from the other UI developers to just make sure they're happy with Excel/GH/Dynamo points of view but final approval should come from @adecler 