### PR TITLE
Make sure that `ComponentRequest` has a location when menu is navigated via keyboard inputs

### DIFF
--- a/BHoM_UI/Global/SearchMenu.cs
+++ b/BHoM_UI/Global/SearchMenu.cs
@@ -68,13 +68,6 @@ namespace BH.UI.Global
         /**** Protected Methods           ****/
         /*************************************/
 
-        protected void NotifySelection(SearchItem item)
-        {
-            NotifySelection(item, null);
-        }
-
-        /*************************************/
-
         protected void NotifySelection(SearchItem item, BH.oM.Geometry.Point location)
         {
             ItemSelected?.Invoke(this, new ComponentRequest { CallerType = item.CallerType, SelectedItem = item.Item, Location = location });

--- a/BHoM_UI/Global/SearchMenu_WinForm.cs
+++ b/BHoM_UI/Global/SearchMenu_WinForm.cs
@@ -68,7 +68,8 @@ namespace BH.UI.Global
 
 
                 //Add the search box
-                m_SearchTextBox = new TextBox() {
+                m_SearchTextBox = new TextBox()
+                {
                     BorderStyle = BorderStyle.FixedSingle,
                     Dock = DockStyle.Top,
                     Font = new Font("Microsoft Sans Serif", 9.75f, System.Drawing.FontStyle.Regular, GraphicsUnit.Point, 0),
@@ -135,7 +136,7 @@ namespace BH.UI.Global
                     if (m_selected < hits.Count)
                     {
                         m_Popup.Hide();
-                        NotifySelection(hits[m_selected]);
+                        NotifySelection(hits[m_selected], new BH.oM.Geometry.Point { X = m_LastPosition.X, Y = m_LastPosition.Y });
                     }
                     return;
                 case Keys.Escape:
@@ -209,6 +210,7 @@ namespace BH.UI.Global
                 yPos += label.Height;
             }
             
+
             m_Popup.Width = maxWidth;
             foreach (Control row in m_SearchResultPanel.Controls) row.Width = maxWidth;
             m_SearchResultPanel.Size = new System.Drawing.Size(maxWidth, yPos);

--- a/BHoM_UI/Global/SearchMenu_Wpf.cs
+++ b/BHoM_UI/Global/SearchMenu_Wpf.cs
@@ -81,7 +81,7 @@ namespace BH.UI.Global
                 grid.Children.Add(m_SearchResultGrid);
 
                 container.Children.Add(m_Popup);
-                m_SearchTextBox.PreviewKeyDown += M_SearchTextBox_PreviewKeyDown; 
+                m_SearchTextBox.PreviewKeyDown += M_SearchTextBox_PreviewKeyDown;
             }
 
             m_SearchTextBox.Text = "";
@@ -109,7 +109,7 @@ namespace BH.UI.Global
                     m_Popup.IsOpen = false;
                     if (m_selected < hits.Count)
                     {
-                        NotifySelection(hits[m_selected]);
+                        NotifySelection(hits[m_selected], new BH.oM.Geometry.Point { X = m_Popup.PlacementRectangle.X, Y = m_Popup.PlacementRectangle.Y });
                     }
                     return;
                 case Key.Escape:


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
This pr support the fixes implement in https://github.com/BHoM/Grasshopper_Toolkit/pull/445 bt does not depend on it.

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
You can test this pr in tandem with the associated Grasshopper_Toolkit one

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `NotifySelection` now always takes a locations
- Make sure that when using the keyboard to navigate the BHoM menu, the component is not created at the mouse cursor location, but at the location of the top left corner of the menu