### PR TITLE
Clear global menu when GH is unloaded

### DIFF
--- a/BHoM_UI/Global/GlobalSearch.cs
+++ b/BHoM_UI/Global/GlobalSearch.cs
@@ -59,6 +59,7 @@ namespace BH.UI.Global
                     {
                         m_SearchMenu = new SearchMenu_Wpf();
                         m_SearchMenu.ItemSelected += M_SearchMenu_ItemSelected;
+                        m_SearchMenu.Disposed += M_SearchMenu_Disposed;
                     }
                     m_SearchMenu.SetParent(container.Content);
                 }
@@ -79,6 +80,7 @@ namespace BH.UI.Global
                     {
                         m_SearchMenu = new SearchMenu_WinForm();
                         m_SearchMenu.ItemSelected += M_SearchMenu_ItemSelected;
+                        m_SearchMenu.Disposed += M_SearchMenu_Disposed;
                     }
                     m_SearchMenu.SetParent(container);
                 }
@@ -95,6 +97,13 @@ namespace BH.UI.Global
         {
             if (request != null)
                 ItemSelected?.Invoke(sender, request);
+        }
+
+        /*************************************/
+
+        private static void M_SearchMenu_Disposed(object sender, EventArgs e)
+        {
+            m_SearchMenu = null;
         }
 
 

--- a/BHoM_UI/Global/SearchMenu.cs
+++ b/BHoM_UI/Global/SearchMenu.cs
@@ -40,6 +40,8 @@ namespace BH.UI.Global
 
         public event EventHandler<ComponentRequest> ItemSelected;
 
+        public event EventHandler Disposed;
+
 
         /*************************************/
         /**** Properties                  ****/
@@ -78,6 +80,13 @@ namespace BH.UI.Global
         protected void NotifySelection(SearchItem item, BH.oM.Geometry.Point location)
         {
             ItemSelected?.Invoke(this, new ComponentRequest { CallerType = item.CallerType, SelectedItem = item.Item, Location = location });
+        }
+
+        /*************************************/
+
+        protected void NotifyDispose()
+        {
+            Disposed?.Invoke(this, null);
         }
 
         /*************************************/

--- a/BHoM_UI/Global/SearchMenu_WinForm.cs
+++ b/BHoM_UI/Global/SearchMenu_WinForm.cs
@@ -47,7 +47,7 @@ namespace BH.UI.Global
             if (container == null)
                 return false;
 
-            if (m_Popup == null)
+            if (m_Popup == null || m_Popup.IsDisposed)
             {
                 // Create the popup form
                 m_Popup = new Form()
@@ -65,6 +65,7 @@ namespace BH.UI.Global
                     BackColor = Color.White
                 };
                 m_Popup.SuspendLayout();
+                m_Popup.Disposed += M_Popup_Disposed;
 
 
                 //Add the search box
@@ -110,6 +111,7 @@ namespace BH.UI.Global
 
             m_Popup.ResumeLayout(false);
             m_Popup.PerformLayout();
+            m_Popup.Visible = false; // Make sure it is not visible before asking to show (otherwise, causes crash)
             m_Popup.Show(container);
             m_SearchTextBox.Focus();
 
@@ -118,6 +120,17 @@ namespace BH.UI.Global
 
             return true;
         }
+
+        /*************************************/
+
+        private void M_Popup_Disposed(object sender, EventArgs e)
+        {
+            m_Popup.Close();
+            m_Popup = null;
+            NotifyDispose();
+        }
+
+        /*************************************/
 
         private void M_Popup_KeyDown(object sender, KeyEventArgs e)
         {

--- a/BHoM_UI/Global/SearchMenu_Wpf.cs
+++ b/BHoM_UI/Global/SearchMenu_Wpf.cs
@@ -84,6 +84,8 @@ namespace BH.UI.Global
                 m_SearchTextBox.PreviewKeyDown += M_SearchTextBox_PreviewKeyDown;
             }
 
+            m_Popup.Unloaded += M_Popup_Unloaded;
+
             m_SearchTextBox.Text = "";
             m_SearchResultGrid.Children.Clear();
             m_Popup.IsOpen = true;
@@ -91,6 +93,19 @@ namespace BH.UI.Global
 
             return true;
         }
+
+        /*************************************/
+        /**** Private Methods             ****/
+        /*************************************/
+
+        private void M_Popup_Unloaded(object sender, RoutedEventArgs e)
+        {
+            m_Popup = null;
+            NotifyDispose();
+
+        }
+
+        /*************************************/
 
         private void M_SearchTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
         {
@@ -126,9 +141,6 @@ namespace BH.UI.Global
             }
         }
 
-
-        /*************************************/
-        /**** Private Methods             ****/
         /*************************************/
 
         private void M_SearchTextBox_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #104

<!-- Add short description of what has been fixed -->

### Test files
See issues for testing procedure


### Additional comments
This fixes the crash for Grasshopper. I have mirrored that for WPF although I have no way of testing it. I also have a feeling that there are other side effects to this unloading/reloading of GH but to be honest this feels like such a niche user case that I will investigate only on a need-to-fix basis.  