### PR TITLE
Allow to remove outputs for the Explode component and show BHoM menu on wire drag-and-released event

### DIFF
--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -159,7 +159,7 @@
     <Compile Include="Global\SearchMenu_WinForm.cs" />
     <Compile Include="Global\SearchMenu_Wpf.cs" />
     <Compile Include="Templates\DataAccessor.cs" />
-    <Compile Include="Templates\InputSelectorMenu.cs" />
+    <Compile Include="Templates\ParamSelectorMenu.cs" />
     <Compile Include="Templates\IItemSelectorMenu.cs" />
     <Compile Include="Templates\IItemSelector.cs" />
     <Compile Include="Templates\MultiChoiceCaller.cs" />

--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -115,6 +115,19 @@ namespace BH.UI.Components
 
         /*************************************/
 
+        public bool RemoveOutput(string name)
+        {
+            if (name == null)
+                return false;
+
+            bool success = OutputParams.RemoveAll(p => p.Name == name) > 0;
+            CompileOutputSetters();
+
+            return success;
+        }
+
+        /*************************************/
+
         public override bool Read(string json)
         {
             if (json == "")

--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -111,7 +111,11 @@ namespace BH.UI.Components
                 }
 
                 for (int i = 0; i < m_CompiledSetters.Count; i++)
-                    m_CompiledSetters[i](DataAccessor, data[i]);
+                {
+                    if (data[i] != null || !OutputParams[i].DataType.UnderlyingType().Type.IsValueType)
+                        m_CompiledSetters[i](DataAccessor, data[i]);
+                }
+                    
             }
             catch (Exception e)
             {

--- a/BHoM_UI/Components/oM/CreateObject.cs
+++ b/BHoM_UI/Components/oM/CreateObject.cs
@@ -153,8 +153,8 @@ namespace BH.UI.Components
             object instance = Activator.CreateInstance(type);
             IEnumerable<ParamInfo> properties = type.GetProperties().Select(x => x.ToBHoM(instance));
 
-            m_InputSelector = new InputSelectorMenu(properties.Select(x => new Tuple<ParamInfo, bool>(x, selectedProperties.Contains(x.Name))).ToList());
-            m_InputSelector.InputToggled += M_InputSelector_InputToggled;
+            m_InputSelector = new ParamSelectorMenu(properties.Select(x => new Tuple<ParamInfo, bool>(x, selectedProperties.Contains(x.Name))).ToList());
+            m_InputSelector.ParamToggled += M_InputSelector_InputToggled;
         }
 
         /*************************************/
@@ -198,7 +198,7 @@ namespace BH.UI.Components
             CompileInputGetters();
 
             if (m_InputSelector != null)
-                m_InputSelector.SetInputCheck(name, false);
+                m_InputSelector.SetParamCheck(name, false);
 
             if (SelectedItem is Type)
                 m_CompiledFunc = Engine.UI.Create.Constructor((Type)SelectedItem, InputParams);
@@ -259,7 +259,7 @@ namespace BH.UI.Components
         public override void AddToMenu(ToolStripDropDown menu)
         {
             if (SelectedItem != null && m_InputSelector != null)
-                m_InputSelector.AddInputList(menu);
+                m_InputSelector.AddParamList(menu);
             else
                 base.AddToMenu(menu);
         }
@@ -269,7 +269,7 @@ namespace BH.UI.Components
         public override void AddToMenu(System.Windows.Controls.ContextMenu menu)
         {
             if (SelectedItem != null && m_InputSelector != null)
-                m_InputSelector.AddInputList(menu);
+                m_InputSelector.AddParamList(menu);
             else
                 base.AddToMenu(menu);
         }
@@ -279,7 +279,7 @@ namespace BH.UI.Components
         public override void AddToMenu(object menu)
         {
             if (SelectedItem != null && m_InputSelector != null)
-                m_InputSelector.AddInputList(menu);
+                m_InputSelector.AddParamList(menu);
             else
                 base.AddToMenu(menu);
         }
@@ -289,7 +289,7 @@ namespace BH.UI.Components
         /**** Private Fields              ****/
         /*************************************/
 
-        InputSelectorMenu m_InputSelector;
+        ParamSelectorMenu m_InputSelector;
 
         /*************************************/
     }

--- a/BHoM_UI/Global/SearchMenu.cs
+++ b/BHoM_UI/Global/SearchMenu.cs
@@ -69,9 +69,9 @@ namespace BH.UI.Global
 
         public abstract bool SetParent(object parent);
 
-        protected abstract void RefreshSearchResults(List<SearchItem> hits);
+        protected virtual void RefreshSearchResults(List<SearchItem> hits) { }
 
-        protected abstract void SetSearchText(string searchText);
+        protected virtual void SetSearchText(string searchText) { }
 
         /*************************************/
 

--- a/BHoM_UI/Global/SearchMenu.cs
+++ b/BHoM_UI/Global/SearchMenu.cs
@@ -49,6 +49,10 @@ namespace BH.UI.Global
 
         public List<SearchItem> PossibleItems { get; set; } = new List<SearchItem>();
 
+        public int NbHits { get; set; } = 20;
+
+        public bool HitsOnEmptySearch { get; set; } = false;
+
 
         /*************************************/
         /**** Constructors                ****/
@@ -65,6 +69,18 @@ namespace BH.UI.Global
 
         public abstract bool SetParent(object parent);
 
+        protected abstract void RefreshSearchResults(List<SearchItem> hits);
+
+        protected abstract void SetSearchText(string searchText);
+
+        /*************************************/
+
+        public void ShowResults(string searchText)
+        {
+            SetSearchText(searchText);
+            RefreshSearchResults(PossibleItems.Hits(searchText, NbHits, HitsOnEmptySearch));
+        }
+
 
         /*************************************/
         /**** Protected Methods           ****/
@@ -79,7 +95,10 @@ namespace BH.UI.Global
 
         protected void NotifySelection(SearchItem item, BH.oM.Geometry.Point location)
         {
-            ItemSelected?.Invoke(this, new ComponentRequest { CallerType = item.CallerType, SelectedItem = item.Item, Location = location });
+            if (item == null)
+                ItemSelected?.Invoke(this, null);
+            else
+                ItemSelected?.Invoke(this, new ComponentRequest { CallerType = item.CallerType, SelectedItem = item.Item, Location = location });
         }
 
         /*************************************/

--- a/BHoM_UI/Global/SearchMenu_Wpf.cs
+++ b/BHoM_UI/Global/SearchMenu_Wpf.cs
@@ -68,7 +68,7 @@ namespace BH.UI.Global
                 m_Popup.Child = grid;
 
                 m_SearchTextBox = new TextBox { MinWidth = m_MinWidth, MinHeight = 24, MaxLines = 1 };
-                m_SearchTextBox.TextChanged += TextBox_TextChanged;
+                m_SearchTextBox.TextChanged += (o, e) => RefreshSearchResults(PossibleItems.Hits(m_SearchTextBox.Text, NbHits, HitsOnEmptySearch));
                 m_SearchTextBox.LostFocus += M_SearchTextBox_LostFocus;
                 m_SearchTextBox.Loaded += M_SearchTextBox_Loaded;
                 m_SearchTextBox.Initialized += M_SearchTextBox_Initialized;
@@ -93,6 +93,7 @@ namespace BH.UI.Global
 
             return true;
         }
+
 
         /*************************************/
         /**** Private Methods             ****/
@@ -120,12 +121,10 @@ namespace BH.UI.Global
                     m_selected = (m_selected + 1) % m_hits;
                     break;
                 case Key.Enter:
-                    List<SearchItem> hits = PossibleItems.Hits(m_SearchTextBox.Text);
-                    m_Popup.IsOpen = false;
+                    List<SearchItem> hits = PossibleItems.Hits(m_SearchTextBox.Text, NbHits, HitsOnEmptySearch);
                     if (m_selected < hits.Count)
-                    {
                         NotifySelection(hits[m_selected], new BH.oM.Geometry.Point { X = m_Popup.PlacementRectangle.X, Y = m_Popup.PlacementRectangle.Y });
-                    }
+                    m_Popup.IsOpen = false;
                     return;
                 case Key.Escape:
                     m_Popup.IsOpen = false;
@@ -160,14 +159,13 @@ namespace BH.UI.Global
         private void M_SearchTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
             m_Popup.IsOpen = false;
+            NotifySelection(null);
         }
 
         /*************************************/
 
-        private void TextBox_TextChanged(object sender, TextChangedEventArgs e)
+        protected override void RefreshSearchResults(List<SearchItem> hits)
         {
-            List<SearchItem> hits = PossibleItems.Hits(m_SearchTextBox.Text);
-
             m_selected = 0;
             m_hits = hits.Count;
 
@@ -199,14 +197,21 @@ namespace BH.UI.Global
                 if (i == m_selected) label.Background = System.Windows.SystemColors.HighlightBrush;
                 label.MouseUp += (a, b) =>
                 {
-                    m_Popup.IsOpen = false;
                     NotifySelection(hit, new BH.oM.Geometry.Point { X = m_Popup.PlacementRectangle.X, Y = m_Popup.PlacementRectangle.Y });
+                    m_Popup.IsOpen = false;
                 };
 
                 Grid.SetRow(label, i);
                 Grid.SetColumn(label, 1);
                 m_SearchResultGrid.Children.Add(label);
             }
+        }
+
+        /*************************************/
+
+        protected override void SetSearchText(string searchText)
+        {
+            m_SearchTextBox.Text = searchText;
         }
 
         /*************************************/

--- a/UI_Engine/Query/Hits.cs
+++ b/UI_Engine/Query/Hits.cs
@@ -36,14 +36,14 @@ namespace BH.Engine.UI
         /**** Public Methods              ****/
         /*************************************/
 
-        public static List<SearchItem> Hits(this List<SearchItem> items, string search, int nbMax = 20)
+        public static List<SearchItem> Hits(this List<SearchItem> items, string search, int nbMax = 20, bool hitsOnEmptySearch = false)
         {
             string text = search.Trim().ToLower();
             string[] parts = text.Split(' ');
 
             List<SearchItem> hits = new List<SearchItem>();
-            if (text.Length > 0)
-                hits = items.Select(x => new Tuple<SearchItem, double>(x, x.Weight(parts)))
+            if (hitsOnEmptySearch || text.Length > 0)
+                hits = items.Select(x => new Tuple<SearchItem, double>(x, x.Weight * x.Weight(parts)))
                                     .Where(x => x.Item2 > 0)
                                     .OrderByDescending(x => x.Item2)
                                     .ThenBy(x => x.Item1.Text)

--- a/UI_Engine/Query/Weight.cs
+++ b/UI_Engine/Query/Weight.cs
@@ -141,7 +141,7 @@ namespace BH.Engine.UI
                         if (properties.Length == 0)
                             return 0;
                         else
-                            return properties.Max(x => DistanceWeight(constraint, x.PropertyType.UnderlyingType().Type));
+                            return properties.Max(x => DistanceWeight(constraint, x.TryGetPropertyType().UnderlyingType().Type));
                     }    
                 }
                 else
@@ -186,6 +186,20 @@ namespace BH.Engine.UI
             }
 
             return 0;
+        }
+
+        /*************************************/
+
+        private static Type TryGetPropertyType(this PropertyInfo property)
+        {
+            try
+            {
+                return property.PropertyType;
+            }
+            catch
+            {
+                return typeof(object);
+            }
         }
 
         /*************************************/

--- a/UI_oM/SearchItem.cs
+++ b/UI_oM/SearchItem.cs
@@ -44,6 +44,8 @@ namespace BH.oM.UI
 
         public string Text { get; set; } = "";
 
+        public double Weight { get; set; } = 1.0;
+
 
         /***************************************************/
     }


### PR DESCRIPTION
### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/1437
This is not a strict dependency in term of code compilation but the change in the UI have highlighted a bug in the engine so better to test with that PR.

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #183 
Closes #196 

### Changelog
- Allow to remove outputs for the Explode component
- Show BHoM menu on wire drag-and-released event

### Additional comments

- Note that if you are doing a test in Excel, you will need this PR for the global menu to still work properly: https://github.com/BHoM/Excel_Toolkit/pull/190
- I am fixing two issues in this PR because those were the issues that had code change overlapping with the adapter level 4 PRs. So it was easier for me to store them and submit them as a batch.