### PR TITLE
Fix Explode output type

### DIFF
--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -332,11 +332,8 @@ namespace BH.UI.Components
         {
             foreach (PropertyInfo prop in type.GetProperties().Where(x => x.CanRead && x.GetMethod.GetParameters().Count() == 0))
             {
-                if (properties.ContainsKey(prop.Name) && properties[prop.Name].Contains(prop.PropertyType))
-                {
-                    BH.Engine.Reflection.Compute.RecordWarning($"The property with name {prop.Name} is present in more than one object with different types. Type will be set to System.Object");
-                    properties[prop.Name] = new List<Type> { typeof(object) };
-                }
+                if (properties.ContainsKey(prop.Name))
+                    properties[prop.Name].Add(prop.PropertyType);
                 else
                     properties[prop.Name] = new List<Type> { prop.PropertyType };
             }


### PR DESCRIPTION
### Issues addressed by this PR

Closes #197

To explain my fix a little more: 
- The code was actually explicitly outputting a `typeof(object)` when the same property name with the same property type was appearing twice
- It was also injecting a bug where, if we had multiple properties with the same name but different types, only the type of the last property would be kept
- The idea with the system is that ALL types under the same name are collected so we can find a common type later (for the moment, always `typeof(object)`. So the solution is ultra simple: just add the type to the list.


### Test files
See test file provided in issue
 I have added the case where properties with the same name have different type to make sure:

![image](https://user-images.githubusercontent.com/16853390/74222385-567abb00-4cef-11ea-9813-0bbdbb38e746.png)

