### PR TITLE
Adding ToNewVersion call for old component deserialisation

### DIFF
--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -258,9 +258,24 @@ namespace BH.UI.Templates
                     {
                         json = Engine.Versioning.Convert.ToNewVersion(json);
                         obj = BH.Engine.Serialiser.Convert.FromJson(json);
+
+                        //If component was sucessfully upgraded, show the message to inform the user.
+                        //This will happen if: Was not serialised as CustomObject (current serialisation method), failed to de-serialised orginially and was able to be upgraded.
+                        if (obj != null && !m_upgradeMessageShown)
+                        {
+                            MessageBox.Show("BHoM 2.3 or earlier components found in this script." + Environment.NewLine +
+                                            "Automatic upgrade of components to 3.0 has been applied. Some wires may have been disconnected." + Environment.NewLine + Environment.NewLine +
+                                            "To preserve wire connectivity as well you could try upgrading to 2.4 first:" + Environment.NewLine +
+                                            "1. Close the script without saving" + Environment.NewLine +
+                                            "2. Downgrade to BHoM 2.4.beta" + Environment.NewLine +
+                                            "3. Open and save the script" + Environment.NewLine + 
+                                            "4. Upgrade back to current version of BHoM and open the script again.","BHoM auto versioning");
+                            m_upgradeMessageShown = true;
+                        }
                     }
 
                     SetItem(obj);
+
                     if (SelectedItem != null)
                         ItemSelected?.Invoke(this, SelectedItem);
                     return true;
@@ -492,6 +507,7 @@ namespace BH.UI.Templates
 
         protected List<Func<DataAccessor, object>> m_CompiledGetters = new List<Func<DataAccessor, object>>();
         protected List<Func<DataAccessor, object, bool>> m_CompiledSetters = new List<Func<DataAccessor, object, bool>>();
+        private static bool m_upgradeMessageShown = false;
 
         /*************************************/
     }

--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -253,6 +253,9 @@ namespace BH.UI.Templates
                 CustomObject component = obj as CustomObject; // Old component, serialised only with the SelectedItem as object
                 if (component == null)
                 {
+                    if (obj == null)
+                        json = Engine.Versioning.Convert.ToNewVersion(json);
+
                     SetItem(BH.Engine.Serialiser.Convert.FromJson(json));
                     if (SelectedItem != null)
                         ItemSelected?.Invoke(this, SelectedItem);

--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -253,10 +253,14 @@ namespace BH.UI.Templates
                 CustomObject component = obj as CustomObject; // Old component, serialised only with the SelectedItem as object
                 if (component == null)
                 {
+                    //If component failed to de-serialise, try upgrade version.
                     if (obj == null)
+                    {
                         json = Engine.Versioning.Convert.ToNewVersion(json);
+                        obj = BH.Engine.Serialiser.Convert.FromJson(json);
+                    }
 
-                    SetItem(BH.Engine.Serialiser.Convert.FromJson(json));
+                    SetItem(obj);
                     if (SelectedItem != null)
                         ItemSelected?.Invoke(this, SelectedItem);
                     return true;

--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -268,8 +268,9 @@ namespace BH.UI.Templates
                                             "To preserve wire connectivity as well you could try upgrading to 2.4 first:" + Environment.NewLine +
                                             "1. Close the script without saving" + Environment.NewLine +
                                             "2. Downgrade to BHoM 2.4.beta" + Environment.NewLine +
-                                            "3. Open and save the script" + Environment.NewLine + 
-                                            "4. Upgrade back to current version of BHoM and open the script again.","BHoM auto versioning");
+                                            "3. Open and save the script" + Environment.NewLine +
+                                            "4. Upgrade back to current version of BHoM and open the script again." + Environment.NewLine + Environment.NewLine +
+                                            "Note that this message will only be shown once per session of the UI.", "BHoM auto versioning");
                             m_upgradeMessageShown = true;
                         }
                     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #210 

<!-- Add short description of what has been fixed -->
After more digging, the issue did not seem to have anything to do with GH crashes on startup, but had to do with versioning toolkit not being triggered at all for the old way of serialising components. Hence, solution below.

Adding a call to Versioning_Engine, `ToNewVersion` for old component if the first deserialisation of the method returns null.

Code looks safe on the Versioning_Engine side, but needs to be tested through properly to make sure it does not break other things, and can only be tested on scripts saved before new serialisation. This is before early July 2019.

### Test files
<!-- Link to test files to validate the proposed changes -->

Example test files found here: https://burohappold.sharepoint.com/:f:/s/BHoM/ErCbq8ntwdJKi1dnjOUv2ZwBLyBl9mRYRvSv3vSORMbsug?e=YvMu8q

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

As this is touching very core framework methods, would be good to get @adecler s signoff before merging.

Problem found while checking versioning after changes in https://github.com/BHoM/BHoM/pull/704