### PR TITLE
Ensuring immutability for SetProperty by deep cloning object

### DIFF
--- a/BHoM_UI/Components/Engine/SetProperty.cs
+++ b/BHoM_UI/Components/Engine/SetProperty.cs
@@ -26,6 +26,7 @@ using BH.UI.Templates;
 using System;
 using System.ComponentModel;
 using System.Reflection;
+using BH.Engine.Base;
 
 namespace BH.UI.Components
 {
@@ -108,6 +109,16 @@ namespace BH.UI.Components
                 base.CompileInputGetters();
         }
 
+        /*************************************/
+
+        public override object Run(object[] inputs)
+        {
+            if (inputs != null && inputs.Length >= 1 && inputs[0] != null)
+            {
+                inputs[0] = inputs[0].DeepClone();
+            }
+            return base.Run(inputs);
+        }
 
         /*************************************/
         /**** Private Fields              ****/

--- a/BHoM_UI/Components/Engine/SetProperty.cs
+++ b/BHoM_UI/Components/Engine/SetProperty.cs
@@ -115,6 +115,7 @@ namespace BH.UI.Components
         {
             if (inputs != null && inputs.Length >= 1 && inputs[0] != null)
             {
+                // Deepclone must be done before the properties are set to ensure immutability
                 inputs[0] = inputs[0].DeepClone();
             }
             return base.Run(inputs);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #226 

<!-- Add short description of what has been fixed -->

Deep clone input to have its property set to make sure the input does not get changed.

This was causing issues when multiple layer property set was being used, causing the upstream obejcts to be changed.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/Es1XVgVIo6xAqXPRZyndtbkBv89NqlXKMUkRutdRaWHNSw?e=zpHf64



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->