### PR TITLE
Avoid generating constructor for types with defined constructor

### DIFF
--- a/UI_Engine/Query/Items.cs
+++ b/UI_Engine/Query/Items.cs
@@ -119,7 +119,8 @@ namespace BH.Engine.UI
         public static IEnumerable<Type> ConstructableTypeItems()
         {
             return Engine.Reflection.Query.BHoMTypeList()
-                .Where(x => !x.IsNotImplemented() && !x.IsDeprecated() && x?.GetInterface("IImmutable") == null && !x.IsEnum && !x.IsAbstract);
+                .Where(x => x != null && !x.IsNotImplemented() && !x.IsDeprecated() && !x.IsEnum && !x.IsAbstract)
+                .Where(x => x.GetConstructors().Where(c => c.GetParameters().Count() > 0).Count() == 0);
         }
 
         /***************************************************/


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #230 

<!-- Add short description of what has been fixed -->


### Test files
Simply make sure that auto constructors are not available in the UI for types that already contain a constructor (e.g. `IImmutable` and `FragmentSet`). All types without defined constructor should still have one generated.


### Additional comments
- There was no way to detect that a constructor was generated by the compiler. I though I could get that from the `CompilerGeneratedAttribute` attribute but that doesn't work since that attribute is not found even on compiler generated constructors.  So I considered that all constructor without arguments is compiler generated. 
- I removed the check on `Immutable` since the check on the number of non-empty constructor covers them.