### PR TITLE
Do not skip `External` keyword in neither namespaces or classes

### DIFF
--- a/UI_Engine/Compute/Organise.cs
+++ b/UI_Engine/Compute/Organise.cs
@@ -97,7 +97,7 @@ namespace BH.Engine.UI
             List<SearchItem> list = paths.Zip(members, (k, v) => new SearchItem { Text = k, Item = v }).ToList();
 
             //Create method tree
-            List<string> toSkip = new List<string> { "Compute", "Convert", "Create", "External", "Modify", "Query" };
+            List<string> toSkip = new List<string> { "Compute", "Convert", "Create", "Modify", "Query" };
             Tree<MemberInfo> tree = Data.Create.Tree(members, paths.Select(x => x.Split('.').Except(toSkip).ToList()).ToList(), "Select an item");
             while (tree.Children.Count == 1 && tree.Children.Values.First().Children.Count > 0)
                 tree.Children = tree.Children.Values.First().Children;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #223
<!-- Add short description of what has been fixed -->
Strategy here is to remove the `External` component, which is unusable in any case since the menu is too slow to display, and only allow the reflected methods in the global menu.

### Test files
<!-- Link to test files to validate the proposed changes -->
This has to tested in tandem with https://github.com/BHoM/BHoM_Adapter/issues/210
You can use https://github.com/BHoM/MidasCivil_Toolkit/pull/203 as a codebase for tests.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->