### PR TITLE
Post build: Decentralise versioning

### DIFF
--- a/UI_PostBuild/CleanDirectory.cs
+++ b/UI_PostBuild/CleanDirectory.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -31,32 +31,23 @@ namespace BHoM_UI
 {
     partial class Program
     {
-        static void Main(string[] args)
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static void CleanDirectory(string folder)
         {
-            // Get programs arguments
-            if (args.Length < 2)
+            DirectoryInfo di = new DirectoryInfo(folder);
+            List<string> skipThese = new List<string> { ".gha", ".xll", ".dna", ".Addin" };
+            foreach (FileInfo file in di.GetFiles())
             {
-                Console.Write("UI PostBuild reqires at least 2 arguments: the source folder and the target folder where the files will be copied.");
-                return;
+                if (!skipThese.Contains(file.Extension))
+                    file.Delete();
             }
-            string sourceFolder = args[0];
-            string targetFolder = args[1];
-
-            //Make sure the source and target folders exists
-            if (!Directory.Exists(sourceFolder))
-                throw new DirectoryNotFoundException("The source folder does not exists: " + sourceFolder);
-            if (!Directory.Exists(targetFolder))
-                Directory.CreateDirectory(targetFolder);
-            else
-                CleanDirectory(targetFolder);
-
-            // Copy Assemblies 
-            CopyAssemblies(sourceFolder, targetFolder);
-
-            // Copy Datasets
-            string targetDatasetsFolder = targetFolder.Replace(@"Assemblies", @"DataSets");
-            CopyDatasets(sourceFolder, targetDatasetsFolder);
+            foreach (DirectoryInfo dir in di.GetDirectories())
+                dir.Delete(true);
         }
+
+        /***************************************************/
     }
 }
-

--- a/UI_PostBuild/CopyAssemblies.cs
+++ b/UI_PostBuild/CopyAssemblies.cs
@@ -56,15 +56,6 @@ namespace BHoM_UI
             AddFilesToList(filesToMove, Directory.GetFiles(Path.Combine(sourceFolder, @"BHoM_UI\Build"), "*.dll"));
             Console.WriteLine("Adding files from BHoM_UI");
 
-            // Add all the test dlls to the list
-            string testPath = Path.Combine(sourceFolder, @"BHoM_Test\Build");
-            if (Directory.Exists(testPath))
-            {
-                AddFilesToList(filesToMove, Directory.GetFiles(Path.Combine(sourceFolder, @"BHoM_Test\Build"), "*.dll"));
-                Console.WriteLine("Adding files from BHoM_Test");
-            }
-
-
             // Add all the Toolkit dlls to the list
             foreach (string path in Directory.GetDirectories(sourceFolder).Where(x => x.EndsWith(@"_Toolkit")))
             {

--- a/UI_PostBuild/CopyAssemblies.cs
+++ b/UI_PostBuild/CopyAssemblies.cs
@@ -1,0 +1,129 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BHoM_UI
+{
+    partial class Program
+    {
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static void CopyAssemblies(string sourceFolder, string targetFolder)
+        {
+            // Create the list of files to move starting with the BHoM.dll 
+            Dictionary<string, List<string>> filesToMove = new Dictionary<string, List<string>>();
+
+            // Add all the oM dlls to the list
+            AddFilesToList(filesToMove, Directory.GetFiles(Path.Combine(sourceFolder, @"BHoM\Build"), "*.dll"));
+            Console.WriteLine("Adding files from BHoM");
+
+            // Add all the Engine dlls to the list
+            AddFilesToList(filesToMove, Directory.GetFiles(Path.Combine(sourceFolder, @"BHoM_Engine\Build"), "*.dll"));
+            Console.WriteLine("Adding files from BHoM_Engine");
+
+            // Add all the Adapter dlls to the list
+            AddFilesToList(filesToMove, Directory.GetFiles(Path.Combine(sourceFolder, @"BHoM_Adapter\Build"), "*.dll"));
+            Console.WriteLine("Adding files from BHoM_Adapter");
+
+            // Add all the UI dlls to the list
+            AddFilesToList(filesToMove, Directory.GetFiles(Path.Combine(sourceFolder, @"BHoM_UI\Build"), "*.dll"));
+            Console.WriteLine("Adding files from BHoM_UI");
+
+            // Add all the test dlls to the list
+            string testPath = Path.Combine(sourceFolder, @"BHoM_Test\Build");
+            if (Directory.Exists(testPath))
+            {
+                AddFilesToList(filesToMove, Directory.GetFiles(Path.Combine(sourceFolder, @"BHoM_Test\Build"), "*.dll"));
+                Console.WriteLine("Adding files from BHoM_Test");
+            }
+
+
+            // Add all the Toolkit dlls to the list
+            foreach (string path in Directory.GetDirectories(sourceFolder).Where(x => x.EndsWith(@"_Toolkit")))
+            {
+                string buildPath = Path.Combine(path, "Build");
+                if (Directory.Exists(buildPath))
+                {
+                    AddFilesToList(filesToMove, Directory.GetFiles(buildPath, "*.dll"));
+                    Console.WriteLine("Adding files from " + path);
+
+                    try
+                    {
+                        foreach (string folderPath in Directory.GetDirectories(buildPath))
+                        {
+                            foreach (string file in Directory.GetFiles(folderPath, "*.*", SearchOption.AllDirectories))
+                            {
+                                string target = file.Replace(buildPath, targetFolder);
+                                Directory.CreateDirectory(Path.GetDirectoryName(target));
+                                File.Copy(file, target, true);
+                            }
+
+                        }
+                    }
+                    catch
+                    {
+                        Console.WriteLine("Failed to copy sub-folders from " + path);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Failed to collect files from " + path);
+                }
+            }
+
+            // Copy all the files accross
+            Console.WriteLine("\nCopying " + filesToMove.Count.ToString() + " files to " + targetFolder);
+            foreach (KeyValuePair<string, List<string>> kvp in filesToMove)
+            {
+                string file = kvp.Value.OrderBy(x => File.GetLastWriteTime(x)).Last();
+                File.Copy(file, Path.Combine(targetFolder, kvp.Key), true);
+            }
+        }
+
+
+        /***************************************************/
+        /**** Helper Methods                            ****/
+        /***************************************************/
+
+        private static void AddFilesToList(Dictionary<string, List<string>> targetList, IEnumerable<string> filesToAdd)
+        {
+            foreach (string file in filesToAdd)
+            {
+                string fileName = file.Substring(file.LastIndexOf('\\') + 1);
+                if (!targetList.ContainsKey(fileName))
+                    targetList.Add(fileName, new List<string> { file });
+                else
+                    targetList[fileName].Add(file);
+            }
+        }
+
+        /***************************************************/
+    }
+}

--- a/UI_PostBuild/CopyDatasets.cs
+++ b/UI_PostBuild/CopyDatasets.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -31,32 +31,43 @@ namespace BHoM_UI
 {
     partial class Program
     {
-        static void Main(string[] args)
-        {
-            // Get programs arguments
-            if (args.Length < 2)
-            {
-                Console.Write("UI PostBuild reqires at least 2 arguments: the source folder and the target folder where the files will be copied.");
-                return;
-            }
-            string sourceFolder = args[0];
-            string targetFolder = args[1];
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
 
-            //Make sure the source and target folders exists
-            if (!Directory.Exists(sourceFolder))
-                throw new DirectoryNotFoundException("The source folder does not exists: " + sourceFolder);
+        private static void CopyDatasets(string sourceFolder, string targetFolder)
+        {
+            foreach (string path in Directory.GetDirectories(sourceFolder).Where((x => x.EndsWith(@"_Datasets") || x.EndsWith(@"_Toolkit"))))
+            {
+                string datasetPath = Path.Combine(path, "DataSets");
+
+                if (Directory.Exists(datasetPath))
+                    CopyJsonInFoldersRecursively(datasetPath, targetFolder);
+            }
+        }
+
+
+        /***************************************************/
+        /**** Helper Methods                            ****/
+        /***************************************************/
+
+        private static void CopyJsonInFoldersRecursively(string sourceFolder, string targetFolder)
+        {
             if (!Directory.Exists(targetFolder))
                 Directory.CreateDirectory(targetFolder);
-            else
-                CleanDirectory(targetFolder);
 
-            // Copy Assemblies 
-            CopyAssemblies(sourceFolder, targetFolder);
+            //Copy all files
+            string[] files = Directory.GetFiles(sourceFolder, "*.json");
+            foreach (string file in files)
+                File.Copy(file, Path.Combine(targetFolder, Path.GetFileName(file)), true);
 
-            // Copy Datasets
-            string targetDatasetsFolder = targetFolder.Replace(@"Assemblies", @"DataSets");
-            CopyDatasets(sourceFolder, targetDatasetsFolder);
+            //Copy all sub folders
+            string[] folders = Directory.GetDirectories(sourceFolder);
+            foreach (string folder in folders)
+                CopyJsonInFoldersRecursively(folder, Path.Combine(targetFolder, Path.GetFileName(folder)));
+
         }
+
+        /***************************************************/
     }
 }
-

--- a/UI_PostBuild/CopyUpgrades.cs
+++ b/UI_PostBuild/CopyUpgrades.cs
@@ -53,11 +53,16 @@ namespace BHoM_UI
 
         private static BsonDocument CollectUpgrades(string sourceFolder)
         {
+            // Get name of versioning file for current version of the BHoM
+            string version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
+            version = version.Split('.').Take(2).Aggregate((a, b) => a + b);
+            string versionFileName = "Versioning_" + version + ".json";
+
             // Create intial dictionaries
             BsonDocument versioning = CreateEmptyUpgradeDocument();
 
             // Collect Versioning files
-            string[] versioningFiles = Directory.GetFiles(sourceFolder, "Versioning.json", SearchOption.AllDirectories);
+            string[] versioningFiles = Directory.GetFiles(sourceFolder, versionFileName, SearchOption.AllDirectories);
             foreach (string file in versioningFiles)
                 ReadVersioningFile(file, versioning);
 

--- a/UI_PostBuild/CopyUpgrades.cs
+++ b/UI_PostBuild/CopyUpgrades.cs
@@ -1,0 +1,201 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using MongoDB.Bson;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BHoM_UI
+{
+    partial class Program
+    {
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static void CopyUpgrades(string sourceFolder, string targetFolder)
+        {
+            BsonDocument content = CollectUpgrades(sourceFolder);
+            CreateUpgradeFile(targetFolder, content);
+        }
+
+
+        /***************************************************/
+        /**** Helper Methods                            ****/
+        /***************************************************/
+
+        private static BsonDocument CollectUpgrades(string sourceFolder)
+        {
+            // Create intial dictionaries
+            BsonDocument versioning = CreateEmptyUpgradeDocument();
+
+            string[] versioningFiles = Directory.GetFiles(sourceFolder, "Versioning.json", SearchOption.AllDirectories);
+            foreach (string file in versioningFiles)
+                ReadVersioningFile(file, versioning);
+
+            // return upgrade document
+            return versioning;
+        }
+
+        /***************************************************/
+
+        private static BsonDocument CreateEmptyUpgradeDocument()
+        {
+            Dictionary<string, object> namespaceUpgrades = new Dictionary<string, object> {
+                { "ToNew", new Dictionary<string, object>() },
+                { "ToOld", new Dictionary<string, object>() }
+            };
+            Dictionary<string, object> typeUpgrades = new Dictionary<string, object> {
+                { "ToNew", new Dictionary<string, object>() },
+                { "ToOld", new Dictionary<string, object>() }
+            };
+            Dictionary<string, object> methodUpgrades = new Dictionary<string, object> {
+                { "ToNew", new Dictionary<string, object>() },
+                { "ToOld", new Dictionary<string, object>() }
+            };
+            Dictionary<string, object> propertyUpgrades = new Dictionary<string, object> {
+                { "ToNew", new Dictionary<string, object>() },
+                { "ToOld", new Dictionary<string, object>() }
+            };
+
+            return new BsonDocument(new Dictionary<string, object>
+            {
+                { "Namespace", namespaceUpgrades },
+                { "Type", typeUpgrades },
+                { "Method", methodUpgrades },
+                { "Property", propertyUpgrades }
+            });
+        }
+
+        /***************************************************/
+
+        private static bool ReadVersioningFile(string file, BsonDocument versioning)
+        {
+            string json = File.ReadAllText(file);
+            BsonDocument upgrades = null;
+            if (!BsonDocument.TryParse(json, out upgrades))
+            {
+                Console.WriteLine("Failed to load the versioning file : " + file);
+                return false;
+            }
+
+            if (upgrades.Contains("Namespace"))
+                CopyAccross(upgrades["Namespace"] as BsonDocument, versioning["Namespace"] as BsonDocument);
+
+            if (upgrades.Contains("Type"))
+                CopyAccross(upgrades["Type"] as BsonDocument, versioning["Type"] as BsonDocument);
+
+            if (upgrades.Contains("Method"))
+                CopyAccross(upgrades["Method"] as BsonDocument, versioning["Method"] as BsonDocument);
+
+            if (upgrades.Contains("Property"))
+                CopyAccross(upgrades["Property"] as BsonDocument, versioning["Property"] as BsonDocument);
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private static void CopyAccross(BsonDocument source, BsonDocument target)
+        {
+            if (source.Contains("ToNew"))
+            {
+                BsonDocument toNew = source["ToNew"] as BsonDocument;
+                foreach (BsonElement element in toNew.Elements)
+                    ((BsonDocument)target["ToNew"]).Add(element);
+            }
+
+            if (source.Contains("ToOld"))
+            {
+                BsonDocument toOld = source["ToOld"] as BsonDocument;
+                foreach (BsonElement element in toOld.Elements)
+                    ((BsonDocument)target["ToOld"]).Add(element);
+            }
+        }
+
+        /***************************************************/
+
+        private static void CreateUpgradeFile(string targetFolder, BsonDocument content)
+        {
+            // Get target folder
+            string folder = Path.Combine(targetFolder, "bin");
+            if (!Directory.Exists(folder))
+                return;
+
+            IEnumerable<string> upgraderFolders = Directory.GetDirectories(folder).Where(x => x.Contains(@"BHoMUpgrader"));
+            if (upgraderFolders.Count() == 0)
+                return;
+
+            string upgraderFolder = upgraderFolders.OrderBy(x => x).Last();
+
+            // Save the content
+            string upgraderFile = Path.Combine(upgraderFolder, "Upgrades.json");
+            string json = FormatJson(content.ToJson());
+            File.WriteAllText(upgraderFile, json);
+
+            Console.WriteLine("Adding versioning file to " + upgraderFolder);
+        }
+
+        /***************************************************/
+
+        private static string FormatJson(string json)
+        {
+            const string TAB = "  ";
+            int indentation = 0;
+            int quoteCount = 0;
+            char previous = ' ';
+            IEnumerable<string> result = json.Select(x =>
+            {
+                int quotes = (x == '"' && previous != '\\') ? quoteCount++ : quoteCount;
+                previous = x;
+                if (quotes % 2 == 1)
+                    return x.ToString();
+
+                switch (x)
+                {
+                    case ',':
+                        return x + Environment.NewLine + String.Concat(Enumerable.Repeat(TAB, indentation));
+                    case ' ':
+                        return "";
+                    case ':':
+                        return ": ";
+                    case '{':
+                    case '[':
+                        return x + Environment.NewLine + String.Concat(Enumerable.Repeat(TAB, ++indentation));
+                    case '}':
+                    case ']':
+                        return Environment.NewLine + String.Concat(Enumerable.Repeat(TAB, --indentation)) + x;
+                    default:
+                        return x.ToString();
+                }
+            });
+
+            return String.Concat(result);
+        }
+
+        /***************************************************/
+    }
+}

--- a/UI_PostBuild/Program.cs
+++ b/UI_PostBuild/Program.cs
@@ -56,6 +56,9 @@ namespace BHoM_UI
             // Copy Datasets
             string targetDatasetsFolder = targetFolder.Replace(@"Assemblies", @"DataSets");
             CopyDatasets(sourceFolder, targetDatasetsFolder);
+
+            // Create Upgrades file
+            CopyUpgrades(sourceFolder, targetFolder);
         }
     }
 }

--- a/UI_PostBuild/UI_PostBuild.csproj
+++ b/UI_PostBuild/UI_PostBuild.csproj
@@ -43,6 +43,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CopyDatasets.cs" />
+    <Compile Include="CopyAssemblies.cs" />
+    <Compile Include="CleanDirectory.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/UI_PostBuild/UI_PostBuild.csproj
+++ b/UI_PostBuild/UI_PostBuild.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MongoDB.Bson, Version=2.10.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.10.3\lib\net452\MongoDB.Bson.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -46,11 +49,13 @@
     <Compile Include="CopyDatasets.cs" />
     <Compile Include="CopyAssemblies.cs" />
     <Compile Include="CleanDirectory.cs" />
+    <Compile Include="CopyUpgrades.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UI_PostBuild/UI_PostBuild.csproj
+++ b/UI_PostBuild/UI_PostBuild.csproj
@@ -36,6 +36,15 @@
     <Reference Include="MongoDB.Bson, Version=2.10.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Bson.2.10.3\lib\net452\MongoDB.Bson.dll</HintPath>
     </Reference>
+    <Reference Include="Reflection_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Reflection_oM">
+      <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="Serialiser_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Serialiser_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/UI_PostBuild/packages.config
+++ b/UI_PostBuild/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MongoDB.Bson" version="2.10.3" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
### Depends on
https://github.com/BHoM/BHoM/pull/823
https://github.com/BHoM/BHoM_Engine/pull/1693
https://github.com/BHoM/Versioning_Toolkit/pull/70

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #245 
Closes #243 

Versioning is now decentralised to each project where changes happened. 
- For method versioning, use the `PreviousVersion` attribute on the new method.
- For everything else, use the `Versioning_32.json` at the root of the project folder.


### Additional comments
- Also closes #243 as it was a very simple and obvious task on the UI_PostBuild

- The content of an empty `Versioning_32.json` file is as follow:

```json
{
  "Namespace": {
    "ToNew": {
    },
    "ToOld": {
    }
  },
  "Type": {
    "ToNew": {
    },
    "ToOld": {
    }
  },
  "Properties": {
    "ToNew": {
    },
    "ToOld": {
    }
  }
}
```