### PR TITLE
Handle HashSet, FragmentSet,... as input list

### DIFF
--- a/BHoM_UI/Components/oM/CreateObject.cs
+++ b/BHoM_UI/Components/oM/CreateObject.cs
@@ -33,6 +33,7 @@ using BH.oM.UI;
 using BH.Engine.UI;
 using System.Windows.Forms;
 using BH.oM.Base;
+using System.Collections;
 
 namespace BH.UI.Components
 {
@@ -241,13 +242,31 @@ namespace BH.UI.Components
                                 SelectedItem = type;
                                 SetInputSelectionMenu(type, InputParams.Select(x => x.Name));
                             }
-
                         }
                     }
+
+                    if (SelectedItem is Type)
+                        m_CompiledFunc = Engine.UI.Compute.Constructor((Type)SelectedItem, InputParams);
                 }
 
-                if (SelectedItem is Type)
-                    m_CompiledFunc = Engine.UI.Compute.Constructor((Type)SelectedItem, InputParams);
+                else if (SelectedItem is Type)
+                {
+                    CustomObject component = Engine.Serialiser.Convert.FromJson(json) as CustomObject;
+                    if (component != null && component.CustomData.ContainsKey("InputParams"))
+                    {
+                        object inputParamsRecord;
+                        List<ParamInfo> inputParams = new List<ParamInfo>();
+                        if (component.CustomData.TryGetValue("InputParams", out inputParamsRecord))
+                            InputParams = (inputParamsRecord as IEnumerable).OfType<ParamInfo>().ToList();
+
+                        Type type = SelectedItem as Type;
+                        SetInputSelectionMenu(type, InputParams.Select(x => x.Name));
+
+                        m_CompiledFunc = Engine.UI.Compute.Constructor(type, InputParams);
+                        CompileInputGetters();
+                    }
+                }
+                
             }
             catch (Exception e)
             {

--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -376,7 +376,7 @@ namespace BH.UI.Templates
             catch (Exception e)
             {
                 RecordError(e, "This component failed to run properly. Inputs cannot be collected properly.\n");
-                inputs = null;
+                return null;
             }
 
             return inputs.ToArray();


### PR DESCRIPTION
### NOTE: Depends on 

https://github.com/BHoM/BHoM/pull/853
https://github.com/BHoM/BHoM_Adapter/pull/228
https://github.com/BHoM/BHoM_Engine/pull/1743

(at least for testing)
   
### Issues addressed by this PR

Closes #154

`IEnumerable` types are can now be properly inputted as lists:

![image](https://user-images.githubusercontent.com/16853390/81135580-5820eb80-8f8b-11ea-8d03-018c5afe380c.png)



### Test files
Use any CreateObject component as add inputs for Tags and Fragments.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
I had to do a second commit to fix a problem created from a previous PR: Added inputs to a `CreateObject` component would not work properly after copy paste or reopening the file.