### PR TITLE
UI_PostBuild: Fix UnauthorizedAccessException on PostBuild CopyUpgrades

### DIFF
--- a/UI_PostBuild/CopyUpgrades.cs
+++ b/UI_PostBuild/CopyUpgrades.cs
@@ -62,7 +62,7 @@ namespace BHoM_UI
             BsonDocument versioning = CreateEmptyUpgradeDocument();
 
             // Collect Versioning files
-            string[] versioningFiles = Directory.GetFiles(sourceFolder, versionFileName, SearchOption.AllDirectories);
+            List<string> versioningFiles = GetVersionFiles(sourceFolder, versionFileName);
             foreach (string file in versioningFiles)
                 ReadVersioningFile(file, versioning);
 
@@ -106,6 +106,16 @@ namespace BHoM_UI
 
         /***************************************************/
 
+        private static List<string> GetVersionFiles(string sourceFolder, string versionFileName)
+        {
+            return Directory.GetDirectories(sourceFolder)
+                .SelectMany(x => Directory.GetDirectories(x))
+                .SelectMany(x => Directory.GetFiles(x, versionFileName))
+                .ToList();
+        }
+
+        /***************************************************/
+
         private static bool ReadVersioningFile(string file, BsonDocument versioning)
         {
             string json = File.ReadAllText(file);
@@ -127,6 +137,8 @@ namespace BHoM_UI
 
             if (upgrades.Contains("Property"))
                 CopyAccross(upgrades["Property"] as BsonDocument, versioning["Property"] as BsonDocument);
+
+            Console.WriteLine("Read the versioning file : " + file);
 
             return true;
         }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #251

I decided to go with Al'second option. I mentioned that it would not work for the Dynamo folder but I started to think this is actually a good thing. That folder is purposefully structured to avoid being transferred to the Roaming folder so it makes sense that it also avoid the versioning picking. Something to deal with Dynamo toolkit either way and should not influence what is done here.
