### PR TITLE
Provide a way to remove event handles from outside the GlobalSearch class

### DIFF
--- a/BHoM_UI/Global/GlobalSearch.cs
+++ b/BHoM_UI/Global/GlobalSearch.cs
@@ -119,6 +119,20 @@ namespace BH.UI.Global
                 m_SearchMenu.PossibleItems.AddRange(items);
         }
 
+        /*************************************/
+
+        public static void RemoveHandler(string declaringType)
+        {
+            if (ItemSelected != null)
+            {
+                foreach (EventHandler<ComponentRequest> d in ItemSelected.GetInvocationList())
+                {
+                    if (d.Method.DeclaringType.FullName == declaringType)
+                        ItemSelected -= d;
+                }
+            }
+        }
+
 
         /*************************************/
         /**** Private Methods             ****/


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Help fixing https://github.com/BHoM/Grasshopper_Toolkit/pull/513

See that PR for details