### PR TITLE
Overwrite MethodCaller.Write() so it saves its original method

### DIFF
--- a/BHoM_UI/Templates/MethodCaller.cs
+++ b/BHoM_UI/Templates/MethodCaller.cs
@@ -21,6 +21,8 @@
  */
 
 using BH.Engine.Reflection;
+using BH.Engine.Serialiser;
+using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using BH.oM.UI;
 using System;
@@ -126,7 +128,7 @@ namespace BH.UI.Templates
                     if (Method is MethodInfo && m_OriginalMethod != null && m_OriginalMethod.IsGenericMethod)
                     {
                         // Try to update the generic method to fit the input types
-                        Method = Compute.MakeGenericFromInputs(m_OriginalMethod, inputs.Select(x => x.GetType()).ToList());
+                        Method = Engine.Reflection.Compute.MakeGenericFromInputs(m_OriginalMethod, inputs.Select(x => x.GetType()).ToList());
                         m_CompiledFunc = Method.ToFunc();
                         return m_CompiledFunc(inputs);
                     }
@@ -143,6 +145,25 @@ namespace BH.UI.Templates
             {
                 BH.Engine.Reflection.Compute.RecordError("The component is not linked to a method.");
                 return null;
+            }
+        }
+
+        /*************************************/
+
+        public override string Write()
+        {
+            try
+            {
+                CustomObject component = new CustomObject();
+                component.CustomData["SelectedItem"] = (m_OriginalMethod == null) ? SelectedItem : m_OriginalMethod;
+                component.CustomData["InputParams"] = InputParams;
+                component.CustomData["OutputParams"] = OutputParams;
+                return component.ToJson();
+            }
+            catch
+            {
+                BH.Engine.Reflection.Compute.RecordError($"{this} failed to serialise itself.");
+                return "";
             }
         }
 


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #265


### Test files
https://burohappold.sharepoint.com/:u:/s/BHoM/Ea5xdAvCGIFNjNsL0a7vIp0BVnVz5v5_H1XqPuOV2hIFwA?e=vDwxva

You will need https://github.com/BHoM/BHoM_Engine/pull/1740 and https://github.com/BHoM/BHoM/pull/852 to test with that file

The `ItemsInRange` component already saved will still fail but any new component created and copy/saved will work fine.

