### PR TITLE
Automatically explode returned IOutputObejcts

### DIFF
--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -22,6 +22,7 @@
 
 using BH.Engine.Reflection;
 using BH.oM.Reflection;
+using BH.oM.Reflection.Interface;
 using BH.oM.UI;
 using System;
 using System.Collections.Generic;
@@ -32,6 +33,7 @@ using BH.Engine.Serialiser;
 using System.Windows.Forms;
 using BH.oM.Base;
 using System.Collections;
+
 
 namespace BH.UI.Templates
 {
@@ -352,25 +354,36 @@ namespace BH.UI.Templates
         {
             try
             {
-                for (int i = 0; i < m_CompiledSetters.Count; i++)
+                if (result is IOutputObject)
                 {
-                    // There is a problem when the output is a list of one apparently (try to explode a tree with a single branch on the first level)
-                    object output = (m_CompiledSetters.Count == 1) ? result : BH.Engine.Reflection.Query.IItem(result, i);
-
-                    try
+                    for (int i = 0; i < m_CompiledSetters.Count; i++)
                     {
-                        m_CompiledSetters[i](DataAccessor, output);
+                        m_CompiledSetters[i](DataAccessor, result.PropertyValue(OutputParams[i].Name));
                     }
-                    catch (Exception e)
+                }
+                else
+                {
+                    for (int i = 0; i < m_CompiledSetters.Count; i++)
                     {
-                        if (m_OriginalOutputTypes.Count > i && m_OriginalOutputTypes[i].IsGenericType)
+
+                        // There is a problem when the output is a list of one apparently (try to explode a tree with a single branch on the first level)
+                        object output = (m_CompiledSetters.Count == 1) ? result : BH.Engine.Reflection.Query.IItem(result, i);
+
+                        try
                         {
-                            m_CompiledSetters[i] = CreateOutputAccessor(output.GetType(), 0);
                             m_CompiledSetters[i](DataAccessor, output);
                         }
-                        else
+                        catch (Exception e)
                         {
-                            throw e;
+                            if (m_OriginalOutputTypes.Count > i && m_OriginalOutputTypes[i].IsGenericType)
+                            {
+                                m_CompiledSetters[i] = CreateOutputAccessor(output.GetType(), 0);
+                                m_CompiledSetters[i](DataAccessor, output);
+                            }
+                            else
+                            {
+                                throw e;
+                            }
                         }
                     }
                 }

--- a/BHoM_UI/Templates/MethodCaller.cs
+++ b/BHoM_UI/Templates/MethodCaller.cs
@@ -281,6 +281,18 @@ namespace BH.UI.Templates
                         }).ToList();
                     }
                 }
+                else if (Method.IsAutoExplode())
+                {
+                    PropertyInfo[] properties = ((MethodInfo)Method).ReturnType.GetProperties();
+
+                    OutputParams = properties.Select(x => new ParamInfo
+                    {
+                        Name = x.Name,
+                        DataType = x.PropertyType,
+                        Description = x.Description(),
+                        Kind = ParamKind.Output
+                    }).ToList();
+                }
                 else
                 {
                     Type nameType = Method.OutputType().UnderlyingType().Type;

--- a/UI_Engine/Query/Items.cs
+++ b/UI_Engine/Query/Items.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using BH.oM.Reflection.Interface;
 
 namespace BH.Engine.UI
 {
@@ -111,7 +112,7 @@ namespace BH.Engine.UI
                     typeof(object), typeof(bool), typeof(byte),
                     typeof(char), typeof(string),
                     typeof(float), typeof(double), typeof(decimal), typeof(short), typeof(int), typeof(long),})
-                .Where(x => !x.IsNotImplemented() && !x.IsDeprecated());
+                .Where(x => !x.IsNotImplemented() && !x.IsDeprecated() && !typeof(IOutputObject).IsAssignableFrom(x));
         }
 
         /***************************************************/
@@ -119,7 +120,7 @@ namespace BH.Engine.UI
         public static IEnumerable<Type> ConstructableTypeItems()
         {
             return Engine.Reflection.Query.BHoMTypeList()
-                .Where(x => x != null && !x.IsNotImplemented() && !x.IsDeprecated() && !x.IsEnum && !x.IsAbstract)
+                .Where(x => x != null && !x.IsNotImplemented() && !x.IsDeprecated() && !x.IsEnum && !x.IsAbstract && !typeof(IOutputObject).IsAssignableFrom(x))
                 .Where(x => x.GetConstructors().Where(c => c.GetParameters().Count() > 0).Count() == 0);
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM/pull/894
https://github.com/BHoM/BHoM_Engine/pull/1805
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #268 

<!-- Add short description of what has been fixed -->

- Auto explode the properties from an returned obejct implementing the IOutputObject interface
- Filter out IOutputObjects from CreateType and ConstructableItem lists

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->