### PR TITLE
Update postbuild and references to ProgramData

### DIFF
--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -233,7 +233,7 @@
   <PropertyGroup>
     <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\ProgramData\BHoM\Assemblies" --onlyUpgrades
 
-xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
+xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -31,40 +31,40 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Adapter_oM">
-      <HintPath>..\..\BHoM_Adapter\Build\Adapter_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM">
-      <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Adapter">
-      <HintPath>..\..\BHoM_Adapter\Build\BHoM_Adapter.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\BHoM_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Data_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_oM">
-      <HintPath>..\..\BHoM\Build\Data_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Geometry_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Geometry_oM, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Geometry_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Library_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Library_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Library_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore">
@@ -74,15 +74,15 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
-      <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Serialiser_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Serialiser_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System">
@@ -119,7 +119,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Versioning_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Versioning_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Versioning_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="WindowsBase">
@@ -231,7 +231,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\ProgramData\BHoM\Assemblies" --onlyUpgrades</PostBuildEvent>
+    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\ProgramData\BHoM\Assemblies" --onlyUpgrades
+
+xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -231,7 +231,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\BHoM\Assemblies"</PostBuildEvent>
+    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\ProgramData\BHoM\Assemblies" --onlyUpgrades</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UI_Engine/UI_Engine.csproj
+++ b/UI_Engine/UI_Engine.csproj
@@ -95,7 +95,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UI_Engine/UI_Engine.csproj
+++ b/UI_Engine/UI_Engine.csproj
@@ -36,32 +36,32 @@
     </Reference>
     <Reference Include="BHoM_Adapter">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM_Adapter\Build\BHoM_Adapter.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\BHoM_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Data_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_oM">
-      <HintPath>..\..\BHoM\Build\Data_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Library_Engine">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM_Engine\Build\Library_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Library_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
-      <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -94,6 +94,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/UI_PostBuild/CopyUpgrades.cs
+++ b/UI_PostBuild/CopyUpgrades.cs
@@ -180,14 +180,19 @@ namespace BHoM_UI
 
         private static void CreateUpgradeFile(string targetFolder, BsonDocument content)
         {
-            // Get target folder
-            string folder = Path.Combine(targetFolder, "bin");
-            if (!Directory.Exists(folder))
+            if (!Directory.Exists(targetFolder))
+            {
+                Console.WriteLine("Target folder for upgrades doesn't exist: " + targetFolder);
                 return;
+            }
+                
 
-            IEnumerable<string> upgraderFolders = Directory.GetDirectories(folder).Where(x => x.Contains(@"BHoMUpgrader"));
+            IEnumerable<string> upgraderFolders = Directory.GetDirectories(targetFolder).Where(x => x.Contains(@"BHoMUpgrader"));
             if (upgraderFolders.Count() == 0)
+            {
+                Console.WriteLine("Upgrades folder doesn't contain upgrader: " + targetFolder);
                 return;
+            }
 
             string upgraderFolder = upgraderFolders.OrderBy(x => x).Last();
 

--- a/UI_PostBuild/CopyUpgrades.cs
+++ b/UI_PostBuild/CopyUpgrades.cs
@@ -191,8 +191,15 @@ namespace BHoM_UI
 
             string upgraderFolder = upgraderFolders.OrderBy(x => x).Last();
 
-            // Save the content
+            // Get target file
             string upgraderFile = Path.Combine(upgraderFolder, "Upgrades.json");
+
+            // target file exists -> copy content accross 
+            // (only adds what is not in content already given how CopySectionAccross works)
+            if (File.Exists(upgraderFile))
+                ReadVersioningFile(upgraderFile, content);
+            
+            // Save the content
             string json = FormatJson(content.ToJson());
             File.WriteAllText(upgraderFile, json);
 

--- a/UI_PostBuild/CopyUpgrades.cs
+++ b/UI_PostBuild/CopyUpgrades.cs
@@ -126,18 +126,7 @@ namespace BHoM_UI
                 return false;
             }
 
-            if (upgrades.Contains("Namespace"))
-                CopyAccross(upgrades["Namespace"] as BsonDocument, versioning["Namespace"] as BsonDocument);
-
-            if (upgrades.Contains("Type"))
-                CopyAccross(upgrades["Type"] as BsonDocument, versioning["Type"] as BsonDocument);
-
-            if (upgrades.Contains("Method"))
-                CopyAccross(upgrades["Method"] as BsonDocument, versioning["Method"] as BsonDocument);
-
-            if (upgrades.Contains("Property"))
-                CopyAccross(upgrades["Property"] as BsonDocument, versioning["Property"] as BsonDocument);
-
+            CopyDocumentAccross(upgrades, versioning);
             Console.WriteLine("Read the versioning file : " + file);
 
             return true;
@@ -145,20 +134,45 @@ namespace BHoM_UI
 
         /***************************************************/
 
-        private static void CopyAccross(BsonDocument source, BsonDocument target)
+        private static void CopyDocumentAccross(BsonDocument source, BsonDocument target)
+        {
+            if (source.Contains("Namespace"))
+                CopySectionAccross(source["Namespace"] as BsonDocument, target["Namespace"] as BsonDocument);
+
+            if (source.Contains("Type"))
+                CopySectionAccross(source["Type"] as BsonDocument, target["Type"] as BsonDocument);
+
+            if (source.Contains("Method"))
+                CopySectionAccross(source["Method"] as BsonDocument, target["Method"] as BsonDocument);
+
+            if (source.Contains("Property"))
+                CopySectionAccross(source["Property"] as BsonDocument, target["Property"] as BsonDocument);
+        }
+
+        /***************************************************/
+
+        private static void CopySectionAccross(BsonDocument source, BsonDocument target)
         {
             if (source.Contains("ToNew"))
             {
-                BsonDocument toNew = source["ToNew"] as BsonDocument;
-                foreach (BsonElement element in toNew.Elements)
-                    ((BsonDocument)target["ToNew"]).Add(element);
+                BsonDocument toNewSource = source["ToNew"] as BsonDocument;
+                BsonDocument toNewTarget = target["ToNew"] as BsonDocument;
+                foreach (BsonElement element in toNewSource.Elements)
+                {
+                    if (!toNewTarget.Contains(element.Name))
+                        toNewTarget.Add(element);
+                }   
             }
 
             if (source.Contains("ToOld"))
             {
-                BsonDocument toOld = source["ToOld"] as BsonDocument;
-                foreach (BsonElement element in toOld.Elements)
-                    ((BsonDocument)target["ToOld"]).Add(element);
+                BsonDocument toOldSource = source["ToOld"] as BsonDocument;
+                BsonDocument toOldTarget = target["ToOld"] as BsonDocument;
+                foreach (BsonElement element in toOldSource.Elements)
+                {
+                    if (!toOldTarget.Contains(element.Name))
+                        toOldTarget.Add(element);
+                }
             }
         }
 

--- a/UI_PostBuild/Program.cs
+++ b/UI_PostBuild/Program.cs
@@ -41,6 +41,7 @@ namespace BHoM_UI
             }
             string sourceFolder = args[0];
             string targetFolder = args[1];
+            bool onlyUpgrades = args.Any(x => x == "--onlyUpgrades");
 
             //Make sure the source and target folders exists
             if (!Directory.Exists(sourceFolder))
@@ -50,13 +51,16 @@ namespace BHoM_UI
             else
                 CleanDirectory(targetFolder);
 
-            // Copy Assemblies 
-            CopyAssemblies(sourceFolder, targetFolder);
+            if (!onlyUpgrades)
+            {
+                // Copy Assemblies 
+                CopyAssemblies(sourceFolder, targetFolder);
 
-            // Copy Datasets
-            string targetDatasetsFolder = targetFolder.Replace(@"Assemblies", @"DataSets");
-            CopyDatasets(sourceFolder, targetDatasetsFolder);
-
+                // Copy Datasets
+                string targetDatasetsFolder = targetFolder.Replace(@"Assemblies", @"DataSets");
+                CopyDatasets(sourceFolder, targetDatasetsFolder);
+            }
+            
             // Create Upgrades file
             CopyUpgrades(sourceFolder, targetFolder);
         }

--- a/UI_PostBuild/Program.cs
+++ b/UI_PostBuild/Program.cs
@@ -42,13 +42,14 @@ namespace BHoM_UI
             string sourceFolder = args[0];
             string targetFolder = args[1];
             bool onlyUpgrades = args.Any(x => x == "--onlyUpgrades");
+            bool cleanTargetDir = args.Any(x => x == "--cleanTargetDir");
 
             //Make sure the source and target folders exists
             if (!Directory.Exists(sourceFolder))
                 throw new DirectoryNotFoundException("The source folder does not exists: " + sourceFolder);
             if (!Directory.Exists(targetFolder))
                 Directory.CreateDirectory(targetFolder);
-            else
+            else if (cleanTargetDir)
                 CleanDirectory(targetFolder);
 
             if (!onlyUpgrades)

--- a/UI_PostBuild/Program.cs
+++ b/UI_PostBuild/Program.cs
@@ -61,9 +61,10 @@ namespace BHoM_UI
                 string targetDatasetsFolder = targetFolder.Replace(@"Assemblies", @"DataSets");
                 CopyDatasets(sourceFolder, targetDatasetsFolder);
             }
-            
+
             // Create Upgrades file
-            CopyUpgrades(sourceFolder, targetFolder);
+            string targetUpgradesFolder = targetFolder.Replace(@"Assemblies", @"Upgrades");
+            CopyUpgrades(sourceFolder, targetUpgradesFolder);
         }
     }
 }

--- a/UI_PostBuild/UI_PostBuild.csproj
+++ b/UI_PostBuild/UI_PostBuild.csproj
@@ -68,7 +68,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y
+xcopy "$(TargetDir)MongoDB.Bson.dll"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UI_PostBuild/UI_PostBuild.csproj
+++ b/UI_PostBuild/UI_PostBuild.csproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y
 xcopy "$(TargetDir)MongoDB.Bson.dll"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UI_PostBuild/UI_PostBuild.csproj
+++ b/UI_PostBuild/UI_PostBuild.csproj
@@ -37,13 +37,13 @@
       <HintPath>..\packages\MongoDB.Bson.2.10.3\lib\net452\MongoDB.Bson.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_oM">
-      <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
     </Reference>
     <Reference Include="Serialiser_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Serialiser_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -67,6 +67,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/UI_oM/UI_oM.csproj
+++ b/UI_oM/UI_oM.csproj
@@ -32,12 +32,12 @@
   <ItemGroup>
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -61,6 +61,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/UI_oM/UI_oM.csproj
+++ b/UI_oM/UI_oM.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy \"$(TargetDir)$(TargetFileName)\"  \"C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
   
### Issues addressed by this PR
https://github.com/BHoM/admin/issues/5

- Add two new arguments to UI_PostBuild: 
  - `--onlyUpgrades`: use this to make sure only upgrade files are created (no dll or dataset)
  - `--cleanTargetDir`: use this to have the target folder cleared first
- Keep the content of the existing `Upgrades.json` file by adding to it instead of replacing it
- Change BHoM_UI postBuild target folder

### Additional comments
- @IsakNaslundBh , I kept the target folder to `Assemblies/bin` to mirror what you did in the engine (`ToNewVersion` file) but actually very easy to use the `BHoM/Upgrades` folder instead as nothing changes in the code, only in the post build command 
- To test the Post_Build process properly, please use https://github.com/BHoM/Versioning_Toolkit/pull/77