### PR TITLE
Fix detection of upgraded SelectedItem for Types

### DIFF
--- a/BHoM_UI/Components/oM/CreateObject.cs
+++ b/BHoM_UI/Components/oM/CreateObject.cs
@@ -306,6 +306,22 @@ namespace BH.UI.Components
                 base.AddToMenu(menu);
         }
 
+        /*************************************/
+
+        protected override bool AreMatching(List<ParamInfo> newList, List<ParamInfo> oldList, bool isInput)
+        {
+            if (isInput && SelectedItem is Type)
+            {
+                Type type = SelectedItem as Type;
+                List<PropertyInfo> props = type.GetProperties().ToList();
+                return oldList.All(x => props.Exists(p => p.Name == x.Name && p.PropertyType == x.DataType));
+            }
+            else
+            {
+                return base.AreMatching(newList, oldList, isInput);
+            }
+        }
+
 
         /*************************************/
         /**** Private Fields              ****/

--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -288,7 +288,7 @@ namespace BH.UI.Templates
                     OutputParams = outputParams;
                     CompileOutputSetters();
                 }
-                else if (!AreMatching(InputParams, inputParams) || !AreMatching(OutputParams, outputParams))
+                else if (!AreMatching(InputParams, inputParams, true) || !AreMatching(OutputParams, outputParams, false))
                 {
                     FindOldIndex(InputParams, inputParams);
                     FindOldIndex(OutputParams, outputParams);
@@ -529,7 +529,7 @@ namespace BH.UI.Templates
 
         /*************************************/
 
-        protected bool AreMatching(List<ParamInfo> newList, List<ParamInfo> oldList)
+        protected virtual bool AreMatching(List<ParamInfo> newList, List<ParamInfo> oldList, bool isInput)
         {
             if (newList.Count != oldList.Count)
                 return false;


### PR DESCRIPTION
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #278

PR #263 broke the ability for the `CreateObject` component to add and remove inputs. The reason is that we lost the ability to easily know if the `SelectedItem` was upgraded by the Versioning engine since it is now black-boxed inside the `FromJson` method. So, in that PR, I tried to detect an upgrade by comparing the inputs and outputs. The problem is that I forgot the case of `CreateObject` where inputs can be modified by the user.

I have now overridden in `CrerateObject` the check done in `Caller`. If the `SelectedItem` is a type, I just make sure that all the component inputs can still be found as property of the object. 

This component is getting messy and too fragile for my liking so I will review it properly next quarter with the general review of the UI. But this PR focuses on fixing the problematic bug before the release of the beta installer. 

### Test files
See issue

