### PR TITLE
Adding ability to log component usage

### DIFF
--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Serialiser;
+using BH.oM.Base;
+using BH.oM.Reflection.Debugging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.UI
+{
+    public static partial class Compute
+    {
+        /*************************************/
+        /**** Public Methods              ****/
+        /*************************************/
+
+        public static void LogUsage(string uiName, Guid componentId, object selectedItem, List<Event> events = null)
+        {
+            try
+            {
+                // Create the log item
+                CustomObject info = Engine.Base.Create.CustomObject(new Dictionary<string, object>
+                {
+                    { "Time", DateTime.UtcNow },
+                    { "UI", uiName },
+                    { "ComponentId", componentId.ToString() },
+                    { "Item", selectedItem },
+                    { "Events", events == null ? new List<Event>() : events.Where(x => x.Type == EventType.Error) }
+                });
+                string json = info.ToJson();
+
+                // Write to the log file
+                StreamWriter log = GetUsageLog(uiName);
+                log.WriteLine(json);
+                log.Flush();
+            }
+            catch { }
+        }
+
+
+        /*************************************/
+        /**** Helper Methods              ****/
+        /*************************************/
+
+        private static StreamWriter GetUsageLog(string uiName)
+        {
+            if (m_UsageLog == null)
+            {
+                string logFolder = @"C:\ProgramData\BHoM\Logs";
+                if (!Directory.Exists(logFolder))
+                    Directory.CreateDirectory(logFolder);
+
+                string filePath = Path.Combine(logFolder, "Usage_" + uiName + "_" + DateTime.UtcNow.Ticks + ".log");
+                FileStream stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
+                m_UsageLog = new StreamWriter(stream);
+
+                AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            }
+
+            return m_UsageLog;
+        }
+
+        /*************************************/
+
+        private static void OnProcessExit(object sender, EventArgs e)
+        {
+            // The file seems to be writable after the UI closed even without this but better safe than sorry.
+            if (m_UsageLog != null)
+                m_UsageLog.Close();
+        }
+
+
+        /*************************************/
+        /**** Static Fields               ****/
+        /*************************************/
+
+        private static StreamWriter m_UsageLog = null;
+
+        /*************************************/
+    }
+}
+

--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -23,6 +23,7 @@
 using BH.Engine.Serialiser;
 using BH.oM.Base;
 using BH.oM.Reflection.Debugging;
+using BH.oM.UI;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -45,14 +46,14 @@ namespace BH.Engine.UI
             try
             {
                 // Create the log item
-                CustomObject info = Engine.Base.Create.CustomObject(new Dictionary<string, object>
+                UsageLogEntry info = new UsageLogEntry
                 {
-                    { "Time", DateTime.UtcNow },
-                    { "UI", uiName },
-                    { "ComponentId", componentId.ToString() },
-                    { "Item", selectedItem },
-                    { "Events", events == null ? new List<Event>() : events.Where(x => x.Type == EventType.Error) }
-                });
+                    UI = uiName,
+                    ComponentId = componentId,
+                    SelectedItem = selectedItem,
+                    Errors = events == null ? new List<Event>() : events.Where(x => x.Type == EventType.Error).ToList()
+                };
+
                 string json = info.ToJson();
 
                 // Write to the log file

--- a/UI_Engine/UI_Engine.csproj
+++ b/UI_Engine/UI_Engine.csproj
@@ -64,9 +64,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Serialiser_Engine, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Serialiser_Engine">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/UI_Engine/UI_Engine.csproj
+++ b/UI_Engine/UI_Engine.csproj
@@ -64,6 +64,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Serialiser_Engine, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -74,6 +78,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\LogUsage.cs" />
     <Compile Include="Compute\LoadAssemblies.cs" />
     <Compile Include="Compute\Organise.cs" />
     <Compile Include="Convert\FromProperty.cs" />

--- a/UI_oM/UI_oM.csproj
+++ b/UI_oM/UI_oM.csproj
@@ -40,6 +40,11 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Reflection_oM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -52,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ComponentRequest.cs" />
+    <Compile Include="UsageLogEntry.cs" />
     <Compile Include="ParamOldIndexFragment.cs" />
     <Compile Include="CustomItem.cs" />
     <Compile Include="SearchConfig.cs" />

--- a/UI_oM/UsageLogEntry.cs
+++ b/UI_oM/UsageLogEntry.cs
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Debugging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.UI
+{
+    public class UsageLogEntry : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual DateTime Time { get; set; } = DateTime.UtcNow;
+
+        public virtual string UI { get; set; } = "";
+
+        public virtual Guid ComponentId { get; set; } = Guid.Empty;
+
+        public virtual object SelectedItem { get; set; } = null;
+
+        public virtual List<Event> Errors { get; set; } = new List<Event>();
+
+
+        /***************************************************/
+    }
+}
+


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #289 

This saves the component usage in log files. The files are located in `C:\ProgramData\BHoM\Logs`. 

- To avoid the potential issue of multiple UIs writing to the same file, I simply have each UI writing into its own. The fil name convention is `Usage_<uiName>_<CreationTimeInTicks>.log`. I think that reduces teh risk of having files with the same name down to zero :smile:.
- Each record saves the following:
  - Time of recording
  - UI hosting the component
  - Component Id
  - Selected BHoM item for the component
  - Error events (that should help us identify which component needs fixing even if the user doesn't raise an issue)
- Note that I considered recording the name of the file containing the component but decided against it because this gives away information that people might not like to share (like project name). 
- There is only one record for each run of teh component even if GH is running it once per input (solved in the [related GH PR](https://github.com/BHoM/Grasshopper_Toolkit/pull/526))
- Multiple runs of a components are however saved as separate records to make sure everything is recorded even if the UI crashes (i.e. saving directly to file instead of temporary in memory). The 'summarisation' of the records will be done when sending to the database.

### Test files
- Don't forget to also compile [the PR for the corresponding UI](https://github.com/BHoM/Grasshopper_Toolkit/pull/526) (I will do Excel and Dynamo after merging this PR to avoid mirroring potential changes in a lot of PRs. I hope you don't mind testing with GH :smile:).
- Just open any GH file and make sure a log is created for it. You can already read that log while GH is still running but you cannot delete it until Rhino is closed.

