### PR TITLE
Create toolkit setting system

### DIFF
--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Components\oM\CreateType.cs" />
     <Compile Include="Components\oM\CreateObject.cs" />
     <Compile Include="Components\oM\CreateDictionary.cs" />
+    <Compile Include="Global\Initialisation.cs" />
     <Compile Include="Global\GlobalSearch.cs" />
     <Compile Include="Global\SearchMenu.cs" />
     <Compile Include="Global\SearchMenu_WinForm.cs" />

--- a/BHoM_UI/Global/Initialisation.cs
+++ b/BHoM_UI/Global/Initialisation.cs
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Adapter;
+using BH.Engine.Reflection;
+using BH.Engine.UI;
+using BH.oM.UI;
+using BH.UI.Components;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace BH.UI.Global
+{
+    public static class Initialisation
+    {
+        /*************************************/
+        /**** Public Methods              ****/
+        /*************************************/
+
+        public static bool Activate()
+        {
+            bool success = true;
+
+            success &= LoadToolkitSettings();
+
+            return success;
+        }
+
+        /*************************************/
+
+        public static bool LoadToolkitSettings()
+        {
+            if (!Directory.Exists(@"C:\ProgramData\BHoM\Settings"))
+            {
+                Engine.Reflection.Compute.RecordWarning(@"C:\ProgramData\BHoM\Settings doesn't exist. Toolkits setting are not loaded.");
+                return false;
+            }
+
+            bool success = true;
+            foreach (string file in Directory.GetFiles(@"C:\ProgramData\BHoM\Settings", "*.cfg"))
+            {
+                string fileName = Path.GetFileNameWithoutExtension(file);
+                ISettings settings = Engine.UI.Query.Settings(fileName);
+
+                // Initialise the toolkit if needed
+                if (settings is IInitialisationSettings)
+                    success = InitialiseToolkit(settings as IInitialisationSettings);
+            }
+
+            return success;
+        }
+
+        /*************************************/
+
+        private static bool InitialiseToolkit(IInitialisationSettings settings)
+        {
+            // Get details about intialisation method to run
+            int separatorIndex = settings.InitialisationMethod.LastIndexOf('.');
+            string typeName = settings.InitialisationMethod.Substring(0, separatorIndex);
+            string methodName = settings.InitialisationMethod.Substring(separatorIndex + 1);
+
+
+            // Get method declaring type
+            List<Type> typeCandidates = Engine.Reflection.Create.AllTypes(typeName).Where(x => x.FullName == typeName).ToList();
+            if (typeCandidates.Count == 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("Type " + typeName + " is unknown");
+                return false;
+            }
+            Type type = typeCandidates.First();
+
+            // Get the method itself
+            MethodInfo method = Engine.Reflection.Create.MethodInfo(type, methodName, new List<Type>());
+            if (method == null)
+            {
+                Engine.Reflection.Compute.RecordWarning("A static method with no argument could not be found for " + settings.InitialisationMethod);
+                return false;
+            }
+
+            // Calling the method
+            try
+            {
+                method.Invoke(null, null);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Engine.Reflection.Compute.RecordWarning("Method " + settings.InitialisationMethod + " failed to run properly during toolkit initialisation. Error: \n" + e.Message);
+                return false;
+            }
+        }
+
+        /*************************************/
+    }
+
+}
+

--- a/BHoM_UI/Templates/Caller.cs
+++ b/BHoM_UI/Templates/Caller.cs
@@ -81,7 +81,12 @@ namespace BH.UI.Templates
 
         public Caller()
         {
-            Engine.UI.Compute.LoadAssemblies();
+            if (!m_Initialised)
+            {
+                m_Initialised = true;
+                Engine.UI.Compute.LoadAssemblies();
+                Global.Initialisation.Activate();
+            }
         }
 
 
@@ -641,6 +646,7 @@ namespace BH.UI.Templates
         protected List<Type> m_OriginalOutputTypes = new List<Type>();
 
         private static bool m_UpgradeMessageShown = false;
+        private static bool m_Initialised = false;
 
         /*************************************/
 

--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -79,6 +79,9 @@ namespace BH.Engine.UI
                 if (!Directory.Exists(logFolder))
                     Directory.CreateDirectory(logFolder);
 
+                // Send the previous logs to the central database
+                SendLogsToDatabase();
+
                 // Get rid of log files old enough to be deleted
                 RemoveDeprecatedLogs(logFolder);
 
@@ -117,6 +120,14 @@ namespace BH.Engine.UI
                 
         }
 
+        /*************************************/
+
+        private static void SendLogsToDatabase()
+        {
+            List<Type> candidates = Reflection.Query.AdapterTypeList().Where(x => x.Name == "BHoMAnalyticsAdapter").ToList();
+            if (candidates.Count == 1)
+                System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(candidates.First().TypeHandle);
+        }
 
         /*************************************/
 

--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -49,6 +49,7 @@ namespace BH.Engine.UI
                 UsageLogEntry info = new UsageLogEntry
                 {
                     UI = uiName,
+                    BHoMVersion = BHoMVersion(),
                     ComponentId = componentId,
                     SelectedItem = selectedItem,
                     Errors = events == null ? new List<Event>() : events.Where(x => x.Type == EventType.Error).ToList()
@@ -126,12 +127,24 @@ namespace BH.Engine.UI
                 m_UsageLog.Close();
         }
 
+        /*************************************/
+
+        public static string BHoMVersion()
+        {
+            if (m_BHoMVersion == null)
+                m_BHoMVersion = Engine.Reflection.Query.BHoMVersion();
+
+            return m_BHoMVersion;
+        }
+
 
         /*************************************/
         /**** Static Fields               ****/
         /*************************************/
 
         private static StreamWriter m_UsageLog = null;
+
+        private static string m_BHoMVersion = null;
 
         private static long m_DeprecationPeriod = 7 * TimeSpan.TicksPerDay; // 7 days in ticks
 

--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -79,9 +79,6 @@ namespace BH.Engine.UI
                 if (!Directory.Exists(logFolder))
                     Directory.CreateDirectory(logFolder);
 
-                // Send the previous logs to the central database
-                SendLogsToDatabase();
-
                 // Get rid of log files old enough to be deleted
                 RemoveDeprecatedLogs(logFolder);
 
@@ -118,15 +115,6 @@ namespace BH.Engine.UI
                 }
             }
                 
-        }
-
-        /*************************************/
-
-        private static void SendLogsToDatabase()
-        {
-            List<Type> candidates = Reflection.Query.AdapterTypeList().Where(x => x.Name == "BHoMAnalyticsAdapter").ToList();
-            if (candidates.Count == 1)
-                System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(candidates.First().TypeHandle);
         }
 
         /*************************************/

--- a/UI_Engine/Compute/SaveSettings.cs
+++ b/UI_Engine/Compute/SaveSettings.cs
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Serialiser;
+using BH.oM.Reflection.Attributes;
+using BH.oM.UI;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace BH.Engine.UI
+{
+    public static partial class Compute
+    {
+        /*************************************/
+        /**** Public Methods              ****/
+        /*************************************/
+
+        [Description(@"Saves the settings for a toolkit into C:\ProgramData\BHoM\Settings. If Any previoulsy saved settings for that toolkit will be overwritten")]
+        [Input("settings", "Settings for a toolkit that need to be saved permanently.")]
+        [Output("success", "Returns true if the settings were saved successfully.")]
+        public static bool SaveSettings(ISettings settings)
+        {
+            if (settings == null)
+            {
+                Engine.Reflection.Compute.RecordError("Settings object is null.");
+                return false;
+            }
+                
+            // Get the config file name
+            string[] splittedNamespace = settings.GetType().Namespace.Split(new char[] { '.' });
+            if (splittedNamespace.Length != 3)
+            {
+                Engine.Reflection.Compute.RecordError("This settings object doesn't have a valid namespace. It should be `BH.oM.ToolkitName` .");
+                return false;
+            }
+
+            string toolkitName = splittedNamespace[2];
+            string filePath = Path.Combine(@"C:\ProgramData\BHoM\Settings", toolkitName + ".cfg");
+
+            // Save the setting in that file
+            File.WriteAllText(filePath, settings.ToJson());
+
+            return true;
+        }
+
+        /*************************************/
+    }
+}
+

--- a/UI_Engine/Query/Settings.cs
+++ b/UI_Engine/Query/Settings.cs
@@ -1,0 +1,106 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Reflection;
+using BH.oM.Reflection.Attributes;
+using BH.oM.UI;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.UI
+{
+    public static partial class Query
+    {
+        /*************************************/
+        /**** Public Methods              ****/
+        /*************************************/
+
+        [Description(@"Extract settings of a given type from C:\ProgramData\BHoM\Settings")]
+        [Input("type", "Object type of the settings you want to recover")]
+        [Output("settings", @"Settings recovered from the corresponding file in C:\ProgramData\BHoM\Settings")]
+        public static ISettings Settings(Type type)
+        {
+            if (type == null)
+            {
+                Engine.Reflection.Compute.RecordError("Settings type is null.");
+                return null;
+            }
+
+            // Get the config file name
+            string[] splittedNamespace = type.Namespace.Split(new char[] { '.' });
+            if (splittedNamespace.Length != 3)
+            {
+                Engine.Reflection.Compute.RecordError("This settings object doesn't have a valid namespace. It should be `BH.oM.ToolkitName` .");
+                return null;
+            }
+
+            string toolkitName = splittedNamespace[2];
+            return Settings(toolkitName);
+        }
+
+        /*************************************/
+
+        [Description(@"Extract settings for a given toolkit from C:\ProgramData\BHoM\Settings")]
+        [Input("toolkitName", "Toolkit you want to recover the settings for")]
+        [Output("settings", @"Settings recovered from the corresponding file in C:\ProgramData\BHoM\Settings")]
+        public static ISettings Settings(string toolkitName)
+        {
+            // Make sure the file exists
+            string filePath = Path.Combine(@"C:\ProgramData\BHoM\Settings", toolkitName + ".cfg");
+            if (!File.Exists(filePath))
+            {
+                Engine.Reflection.Compute.RecordWarning("There is no setting file for toolkit " + toolkitName + ".");
+                return null;
+            }
+
+            // Get the json out of the file
+            string json = "";
+            try
+            {
+                json = File.ReadAllText(filePath);
+            }
+            catch
+            {
+                Reflection.Compute.RecordError("There setting file " + filePath + " cannot be read. Make sure it isn't locked by another program.");
+                return null;
+            }
+
+            // Convert back into a Settings object
+            object settings = Engine.Serialiser.Convert.FromJson(json);
+            if (settings is ISettings)
+                return settings as ISettings;
+            else
+            {
+                Reflection.Compute.RecordError("The content of the file" + filePath + " doesn't contain a valid ISettings object.");
+                return null;
+            }
+        }
+
+        /*************************************/
+    }
+}
+

--- a/UI_Engine/UI_Engine.csproj
+++ b/UI_Engine/UI_Engine.csproj
@@ -78,6 +78,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\SaveSettings.cs" />
     <Compile Include="Compute\LogUsage.cs" />
     <Compile Include="Compute\LoadAssemblies.cs" />
     <Compile Include="Compute\Organise.cs" />
@@ -86,6 +87,7 @@
     <Compile Include="Compute\Constructor.cs" />
     <Compile Include="Create\ParamInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\Settings.cs" />
     <Compile Include="Query\Hits.cs" />
     <Compile Include="Query\Items.cs" />
     <Compile Include="Query\Weight.cs" />

--- a/UI_oM/Interfaces/IInitialisationSettings.cs
+++ b/UI_oM/Interfaces/IInitialisationSettings.cs
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.UI
+{
+    [Description("Toolkit Settings that contain an initialisation method to be ran when the UI starts.")]
+    public interface IInitialisationSettings : IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        string InitialisationMethod { get; }
+
+        /***************************************************/
+    }
+}
+

--- a/UI_oM/Interfaces/ISettings.cs
+++ b/UI_oM/Interfaces/ISettings.cs
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.UI
+{
+    [Description("Toolkit Settings that need to be saved permanently.")]
+    public interface ISettings 
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+
+        /***************************************************/
+    }
+}
+

--- a/UI_oM/UI_oM.csproj
+++ b/UI_oM/UI_oM.csproj
@@ -57,6 +57,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ComponentRequest.cs" />
+    <Compile Include="Interfaces\IInitialisationSettings.cs" />
+    <Compile Include="Interfaces\ISettings.cs" />
     <Compile Include="UsageLogEntry.cs" />
     <Compile Include="ParamOldIndexFragment.cs" />
     <Compile Include="CustomItem.cs" />

--- a/UI_oM/UsageLogEntry.cs
+++ b/UI_oM/UsageLogEntry.cs
@@ -40,6 +40,8 @@ namespace BH.oM.UI
 
         public virtual string UI { get; set; } = "";
 
+        public virtual string BHoMVersion { get; set; } = "";
+
         public virtual Guid ComponentId { get; set; } = Guid.Empty;
 
         public virtual object SelectedItem { get; set; } = null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
Supports the [PR in BHoMAnalytics](https://github.com/BHoM/BHoMAnalytics_Toolkit/pull/2).

### Issues addressed by this PR

This now provides a solution for toolkits to save some settings in `C:\ProgramData\BHoM\Settings`. Basically, each toolkit can have its own config file with the corresponding name there. I have exposed the methods to read and save settings so users can modify those settings without having to mess directly with a json file. Two immediate usages of this come to mind:
- BHoMAnalytics can store the information about the database where the usage data is sent -> that's what the BHoMAnalytics PR does)
- User settings for the UI (e.g. user tags, customised look,....) -> soon in oyu favorite BHoM UI 😄 

The other thing I did here is to let the toolkits execute some code when the BHoM is started. This is directly relevant for BHoMAnalytics again since it is now able to send the usage logs to the database without having any hard-coded reference to BHoMAnalytics in the BHoM UI at all. This means that if developers outside the Collective need a similar initialisation phase for their toolkit, they don't need to modify the BHoM UI. 

Here's how it works:
- At launch, BHoM UI will look for all settings in the Settings folder that implement the `IInitialisationSettings` interface. 
- It will then try to find the method provided as a string by the only property of that interface
- If that method is found, it will be run. 
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

See https://github.com/BHoM/BHoMAnalytics_Toolkit/issues/1

### Changelog
- New toolkit settings system with ability to save and load settings to and from `C:\ProgramData\BHoM\Settings`
- Ability for toolkits to Initialise themselves when UI is started if they register an initialisation method in `BHoM\Settings'
