### PR TITLE
Fix bug when deserialising components saved with input duplicates

### DIFF
--- a/BHoM_UI/Caller/Read.cs
+++ b/BHoM_UI/Caller/Read.cs
@@ -121,9 +121,9 @@ namespace BH.UI.Base
 
             // Make sure that saved selection is copied over
             if (inputParams != null)
-                SelectInputs(inputParams.ToDictionary(x => x.Name, x => x.IsSelected));
+                SelectInputs(inputParams.GroupBy(x => x.Name).Select(g => g.First()).ToDictionary(x => x.Name, x => x.IsSelected));
             if (outputParams != null)
-                SelectOutputs(outputParams.ToDictionary(x => x.Name, x => x.IsSelected));
+                SelectOutputs(outputParams.GroupBy(x => x.Name).Select(g => g.First()).ToDictionary(x => x.Name, x => x.IsSelected));
 
             // Look for changes
             CallerUpdate update = new CallerUpdate


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #303

See issue

### Additional comments
The name input is still incorrect as expected due the component being saved in an incorrect state. Even if I don't plan to cover all cases of components saved in incorrect state, there is things we can do to improve the handling of this specific situation. That needs to be done in Grasshopper though as BHoM_UI itself has no way of knowing the state of the GH components.