### PR TITLE
Possible fix to Grasshopper sometimes freezing at launch

### DIFF
--- a/BHoM_UI/Global/Initialisation.cs
+++ b/BHoM_UI/Global/Initialisation.cs
@@ -66,12 +66,19 @@ namespace BH.UI.Base.Global
             bool success = true;
             foreach (string file in Directory.GetFiles(@"C:\ProgramData\BHoM\Settings", "*.cfg"))
             {
-                string fileName = Path.GetFileNameWithoutExtension(file);
-                ISettings settings = Engine.UI.Query.Settings(fileName);
+                try
+                {
+                    string fileName = Path.GetFileNameWithoutExtension(file);
+                    ISettings settings = Engine.UI.Query.Settings(fileName);
 
-                // Initialise the toolkit if needed
-                if (settings is IInitialisationSettings)
-                    success = InitialiseToolkit(settings as IInitialisationSettings);
+                    // Initialise the toolkit if needed
+                    if (settings is IInitialisationSettings)
+                        success = InitialiseToolkit(settings as IInitialisationSettings);
+                }
+                catch (Exception e)
+                {
+                    Engine.Reflection.Compute.RecordWarning(@"Failed to load one of the config file. Error:\n" + e.Message);
+                }
             }
 
             return success;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Not sure if it actually solves the problems but this is related to issues #305. 
I suggest we keep that issue open even if we merge this PR though. As I never had that issue on my machine, this PR is just a blind guess at what might be causing the issue. An additional try-catch cannot hurt though 😄 

It is worth mentioning that 
- BHoM_Analytics is running asynchronously so there is not risk there for it to freeze Grasshopper. 
- Usage log files are not accessed during initialisation so no risk on that side either.

### Test files
Keep opening and closing Grasshopper I guess 😋 

