### PR TITLE
Prevent input types to be modified by user for SetProperty

### DIFF
--- a/BHoM_UI/Components/Engine/SetProperty.cs
+++ b/BHoM_UI/Components/Engine/SetProperty.cs
@@ -111,6 +111,15 @@ namespace BH.UI.Base.Components
         }
 
         /*************************************/
+
+        public override bool UpdateInput(int index, string name, Type type = null)
+        {
+            // Do not let update input types (they are detected automatically in CollectInputs())
+            return true;
+        }
+
+
+        /*************************************/
         /**** Private Fields              ****/
         /*************************************/
 


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #309

When running the testing procedure on Grasshopper today, I realised the input type of the `SetProperty` was correctly staying on `List` after reopening the file. This was in contradiction with issue #309.

The problem was that, since the time when that file was created, Grasshopper is now asking BHoM_UI to update internal types of parameters when they are modified by the user. So here's the situation:
- On test file: the `value` input was saved as an `Object`
- On any new `SetProperty` component: the `value` input was saved as an `List<Object>`

Intuitively, the new version feels better but, here's the catch: when the `SetProperty` component is deserialised, it doesn't know what object it has to set the property of yet so it will always consider the type of `value` as `Object`. When it was saved as `List<Object>`, this will be considered as something that needs to be updated. This is why it will always go back to object instead of list. 

Ultimately, I think the whole system could be improved so that the user doesn't even have to manually change the type to List when the component knows very well that it is what it needs. Thanks to the new update system, this is something pretty easy to do (when the component detects it needs to change to list, it sends a `CalerUpdate` to Grasshopper. 

This is not something I want to do this close to the beta release though. So I decided to things to how they were in the testing file. This means the `value` input type is always saved as `Object` and never anything else. This way, there is never a request for change (After all, the `SetProperty` component is a static one, using always the same method so no need for fancy param updates).

Apologies for the wall of text but I wanted to make it clear why I chose this solution for this fix. This close to the beta release, I want to make sure the changes I make are 100% safe. I have also added quite a few of you as reviewer to make sure I didn't miss anything. If you have any doubt, please flag it up. Otherwise, I think this is a nice fix to have merged for the beta.

Note: As you can see in https://github.com/search?q=org%3ABHoM+UpdateInput&type=code, this change only affects Grasshopper. Excel doesn't need this feature and Dynamo is not leveraging this functionality yet. 

### Test files
recreate this small script :
![image](https://user-images.githubusercontent.com/26874773/93872396-5fddf400-fcd0-11ea-8238-65b588164390.png)
Save, close the file and reopen. This should still work after reopening.
