### PR TITLE
Adding null checks to Caller.UpdateInput

### DIFF
--- a/BHoM_UI/Caller/IO_CRUD.cs
+++ b/BHoM_UI/Caller/IO_CRUD.cs
@@ -88,10 +88,10 @@ namespace BH.UI.Base
 
             if (type != null)
             {
-                InputParams[index].DataType = type;
-
                 if (type != InputParams[index].DataType)
                     m_CompiledGetters[index] = Engine.UI.Create.InputAccessor(m_DataAccessor.GetType(), type);
+
+                InputParams[index].DataType = type;
             }
                 
             return true;

--- a/BHoM_UI/Caller/IO_CRUD.cs
+++ b/BHoM_UI/Caller/IO_CRUD.cs
@@ -43,7 +43,7 @@ namespace BH.UI.Base
 
         public virtual bool AddInput(int index, string name, Type type = null)
         {
-            if (name == null)
+            if (name == null || index < 0)
                 return false;
 
             ParamInfo match = InputParams.Find(x => x.Name == name);
@@ -75,20 +75,25 @@ namespace BH.UI.Base
 
         /*************************************/
 
-        public virtual bool UpdateInput(int index, string name, Type type = null)
+        public virtual bool UpdateInput(int index, string name = null, Type type = null)
         {
+            if (index < 0)
+                return false;
+
             if (InputParams.Count <= index)
                 return AddInput(index, name, type);
-
-            if (type != InputParams[index].DataType)
-                m_CompiledGetters[index] = Engine.UI.Create.InputAccessor(m_DataAccessor.GetType(), type);
 
             if (name != null)
                 InputParams[index].Name = name;
 
             if (type != null)
+            {
                 InputParams[index].DataType = type;
 
+                if (type != InputParams[index].DataType)
+                    m_CompiledGetters[index] = Engine.UI.Create.InputAccessor(m_DataAccessor.GetType(), type);
+            }
+                
             return true;
         }
 

--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -119,10 +119,13 @@ namespace BH.UI.Base.Components
 
         public override void AddToMenu(System.Windows.Controls.ContextMenu menu)
         {
-            System.Windows.Controls.MenuItem item = new System.Windows.Controls.MenuItem { Header = "Update Outputs" };
-            item.Click += (sender, e) => CollectOutputTypes();
-            menu.Items.Add(item);
-            menu.Items.Add(new Separator());
+            if (menu.Items.OfType<System.Windows.Controls.MenuItem>().All(x => x.Header.ToString() != "Update Outputs"))
+            {
+                System.Windows.Controls.MenuItem item = new System.Windows.Controls.MenuItem { Header = "Update Outputs" };
+                item.Click += (sender, e) => CollectOutputTypes();
+                menu.Items.Add(item);
+                menu.Items.Add(new Separator());
+            }
 
             base.AddToMenu(menu);
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #318

Dynamo doesn't always provide valid parameters (name and type) to `Caller.UpdateInput` so safer to add a few extra checks.
I have also allowed name to be null for additional flexibility on when that method can be triggered.

As soon as this PR is merged, I'll push the changes on the side of Dynamo to the open PR.

#### Test file(s):
A  simple review of the code should be enough here as it is purely adding null checks
