### PR TITLE
Fix ParamSelector menu getting out of sync in Dynamo

### DIFF
--- a/BHoM_UI/Menus/ParamSelectorMenu.cs
+++ b/BHoM_UI/Menus/ParamSelectorMenu.cs
@@ -68,8 +68,12 @@ namespace BH.UI.Base.Menus
                     e.Cancel = true;
             };
 
-            foreach (ParamInfo param in m_Params)
-                AppendMenuItem(listMenu.DropDown, param.Name, param.IsSelected, !param.IsRequired);
+            menu.Opened += (sender, e) =>
+            {
+                listMenu.DropDown.Items.Clear();
+                foreach (ParamInfo param in m_Params)
+                    AppendMenuItem(listMenu.DropDown, param.Name, param.IsSelected, !param.IsRequired);
+            };   
         }
 
         /*************************************/
@@ -81,8 +85,12 @@ namespace BH.UI.Base.Menus
             listMenu.SubmenuClosed += Menu_Closing;
             menu.Items.Add(listMenu);
 
-            foreach (ParamInfo param in m_Params)
-                AppendMenuItem(listMenu, param.Name, param.IsSelected, !param.IsRequired);
+            menu.Opened += (sender, e) =>
+            {
+                listMenu.Items.Clear();
+                foreach (ParamInfo param in m_Params)
+                    AppendMenuItem(listMenu, param.Name, param.IsSelected, !param.IsRequired);
+            };
         }
 
         /*************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #320

See issue

### Test files
Just check the menu after deleting some of the inputs using the `-` button both in Grasshopper and Dynamo.

