### PR TITLE
Leverage attributes to better control auto-create components

### DIFF
--- a/BHoM_UI/Caller/Run.cs
+++ b/BHoM_UI/Caller/Run.cs
@@ -125,6 +125,13 @@ namespace BH.UI.Base
                         try
                         {
                             input = m_CompiledGetters[i](m_DataAccessor, index);
+
+                            if (input == null || input.ToString() == "")
+                            {
+                                string warning = InputParams[i].DefaultValueWarning;
+                                if (!string.IsNullOrEmpty(warning))
+                                    Engine.Reflection.Compute.RecordNote(warning);
+                            }
                         }
                         catch (Exception e)
                         {
@@ -141,8 +148,13 @@ namespace BH.UI.Base
                         index++;
                     } 
                     else
+                    {
+                        string warning = InputParams[i].DefaultValueWarning;
+                        if (!string.IsNullOrEmpty(warning))
+                            Engine.Reflection.Compute.RecordNote(warning);
                         input = InputParams[i].DefaultValue;
-                    
+                    }
+                        
                     inputs.Add(input);
                 }
             }

--- a/UI_Engine/Create/ParamInfo.cs
+++ b/UI_Engine/Create/ParamInfo.cs
@@ -62,7 +62,9 @@ namespace BH.Engine.UI
                 Name = property.Name,
                 DataType = property.PropertyType,
                 Description = property.IDescription(),
-                Kind = ParamKind.Input
+                Kind = ParamKind.Input,
+                IsRequired = property.IsRequired(),
+                DefaultValueWarning = property.DefaultValueWarning()
             };
 
             if (instance != null)

--- a/UI_Engine/Query/Items.cs
+++ b/UI_Engine/Query/Items.cs
@@ -128,7 +128,7 @@ namespace BH.Engine.UI
         public static IEnumerable<Type> ConstructableTypeItems()
         {
             return Engine.Reflection.Query.BHoMTypeList()
-                .Where(x => x != null && !x.IsNotImplemented() && !x.IsDeprecated() && !x.IsEnum && !x.IsAbstract && !x.FullName.Contains("+<>c"))
+                .Where(x => x != null && !x.IsNotImplemented() && !x.IsDeprecated() && x.IsAutoConstructorAllowed() && !x.IsEnum && !x.IsAbstract && !x.FullName.Contains("+<>c"))
                 .Where(x => x.GetConstructors().Where(c => c.GetParameters().Count() > 0).Count() == 0);
         }
 

--- a/UI_oM/ParamInfo.cs
+++ b/UI_oM/ParamInfo.cs
@@ -49,6 +49,8 @@ namespace BH.oM.UI
 
         public virtual bool IsSelected { get; set; } = true;
 
+        public virtual string DefaultValueWarning { get; set; } = "";
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/1020
https://github.com/BHoM/BHoM_Engine/pull/2057
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #205

see the oM PR for more details

The support for converting deleted Create methods into auto-constructors was already existing in the BHoM_UI code but was broken after the refactoring. It was a small enough fix and relevant enough for this PR that  Ideceided to do it here.

Closes https://github.com/BHoM/Versioning_Toolkit/issues/96
### Test files
Just add those attributes to your favorite class and test that it works in the UI

