### PR TITLE
Align to change in SetProperty method name

### DIFF
--- a/BHoM_UI/Components/Engine/SetProperty.cs
+++ b/BHoM_UI/Components/Engine/SetProperty.cs
@@ -51,7 +51,7 @@ namespace BH.UI.Base.Components
         /**** Constructors                ****/
         /*************************************/
 
-        public SetPropertyCaller() : base(typeof(Engine.Reflection.Modify).GetMethod("PropertyValue")) { }
+        public SetPropertyCaller() : base(typeof(Engine.Reflection.Modify).GetMethod("SetPropertyValue")) { }
 
 
         /*************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/2066

   
### Issues addressed by this PR
See https://github.com/BHoM/BHoM_Engine/pull/2066 for details


### Test files
Just make sure that the `SetProperty` component is still working for both new and saved ones. Note that I have also tested for setting of subproperies and it still works fine (e.g. `Location.X`). The other cool thing is that the `SetProperty` component is not limited to BHoM objects anymore (before, you couldn't set a property of a BHoM Point for example). That aligns better with previous changes on things like `ToJson`
