### PR TITLE
Improved name change support on method arguments

### DIFF
--- a/UI_Engine/Query/MatchWith.cs
+++ b/UI_Engine/Query/MatchWith.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.UI
                 // First, get all the pairs that have matching names
                 foreach (ParamInfo newParam in added.ToList())
                 {
-                    ParamInfo oldParam = removed.Find(x => x.Name == newParam.Name);
+                    ParamInfo oldParam = removed.Find(x => newParam.IsMatchingName(x.Name));
                     if (oldParam != null)
                     {
                         matches[newParam] = oldParam;
@@ -80,6 +80,19 @@ namespace BH.Engine.UI
             }
 
             return matches;
+        }
+
+        /*************************************/
+        /**** Private Methods             ****/
+        /*************************************/
+
+        private static bool IsMatchingName(this ParamInfo param, string name)
+        {
+            if (param.Name == name)
+                return true;
+
+            PreviousNamesFragment fragment = param.Fragments.OfType<PreviousNamesFragment>().FirstOrDefault();
+            return fragment != null && fragment.OldNames.Contains(name);
         }
 
         /*************************************/

--- a/UI_oM/PreviousNamesFragment.cs
+++ b/UI_oM/PreviousNamesFragment.cs
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.UI
+{
+    public class PreviousNamesFragment : IFragment
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual List<string> OldNames { get; set; } = new List<string>();
+
+
+        /***************************************************/
+    }
+}
+

--- a/UI_oM/UI_oM.csproj
+++ b/UI_oM/UI_oM.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="ComponentRequest.cs" />
     <Compile Include="Interfaces\IDataAccessor.cs" />
+    <Compile Include="PreviousNamesFragment.cs" />
     <Compile Include="Updates\OutputsUpdate.cs" />
     <Compile Include="Updates\InputsUpdate.cs" />
     <Compile Include="Updates\ParamReplaced.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/1062

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/Grasshopper_Toolkit/issues/561
(might have to close manually that one)

When multiple method arguments of the same type have their name changed, the wires are lost after reopening the file. This fixes that by providing a new `PreviousInputNamesAttribute`. 


### Test files
- Create a component that has multiple inputs of the same type, connect all the inputs and save the file.
- Change those inputs names on the method itself and recompile
- Check that the wires have disappeared if you reopen the file.
- Add the new `PreviousInputNamesAttribute` for those changed inputs and recompile
- Check that the wires are still there when you reopen the file.

