### PR TITLE
Make it easy to clear the value of a property

### DIFF
--- a/BHoM_UI/Components/Engine/SetProperty.cs
+++ b/BHoM_UI/Components/Engine/SetProperty.cs
@@ -80,7 +80,12 @@ namespace BH.UI.Base.Components
                         {
                             PropertyInfo propInfo = objType.GetProperty(propName);
                             if (propInfo != null)
-                                m_CompiledGetters[2] = Engine.UI.Create.InputAccessor(m_DataAccessor.GetType(), propInfo.PropertyType);
+                            {
+                                Type propType = propInfo.PropertyType;
+                                if (propType.IsValueType)
+                                    propType = typeof(object);
+                                m_CompiledGetters[2] = Engine.UI.Create.InputAccessor(m_DataAccessor.GetType(), propType);
+                            }    
                         }
                     }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/2142

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #141 

With this PR, it is now easy to clear the value of a property by leaving the `value` input empty. Here's how it behaves:
- Value types like primitives and enums are set to their default value (value types cannot be null)
- Any IEnumerable is set to an empty version of that type.
- Strings are set to an empty string (it could be set to null but I think this is the only case where it makes more sense not to)
- All other objects are set to null.

Looks like a lot of cases listed like that but I found it pretty intuitive when actually used. Let me know if you disagree.

### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_UI/BHoM_UI-Issue141-SetPropertyDefault.gh?csf=1&web=1&e=h7RH22

### Additional comments
Note that the issue @kThorsager was complaining about related to the list type disappearing when copying the component has been solved during the refactoring of the UI.