### PR TITLE
BHoM_UI: Detect startup using UTC time instead of local time

### DIFF
--- a/BHoM_UI/Components/Engine/GetEvents.cs
+++ b/BHoM_UI/Components/Engine/GetEvents.cs
@@ -77,8 +77,8 @@ namespace BH.UI.Base.Components
             List<Event> startupEvents = new List<Event>();
             if (Initialisation.CompletionTime != null)
             {
-                startupEvents = events.Where(x => x.Time <= Initialisation.CompletionTime).ToList();
-                events = events.Where(x => x.Time > Initialisation.CompletionTime).ToList();
+                startupEvents = events.Where(x => x.UtcTime <= Initialisation.CompletionTime).ToList();
+                events = events.Where(x => x.UtcTime > Initialisation.CompletionTime).ToList();
             }
 
             if (since != null)

--- a/BHoM_UI/Global/Initialisation.cs
+++ b/BHoM_UI/Global/Initialisation.cs
@@ -57,7 +57,7 @@ namespace BH.UI.Base.Global
 
             success &= LoadToolkitSettings();
 
-            CompletionTime = DateTime.Now;
+            CompletionTime = DateTime.UtcNow;
 
             return success;
         }

--- a/BHoM_UI/Global/SearchMenu.cs
+++ b/BHoM_UI/Global/SearchMenu.cs
@@ -62,7 +62,7 @@ namespace BH.UI.Base.Global
         public SearchMenu()
         {
             PossibleItems = GetAllPossibleItems();
-            Initialisation.CompletionTime = DateTime.Now;
+            Initialisation.CompletionTime = DateTime.UtcNow;
         }
 
         /*************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/1092

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #335

It seems that some events recorded in Revit are using UTC time instead of local time despite using `DateTime.Now` and not `DateTime.UtcNow`. So detecting startup events can only be done reliably using UTC time everywhere. 

It is important to note, that I keep using local time for the `since` input of `GetEvents` because this is something provided by the user. 


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->