### PR TITLE
CI/CD: Align to changes in Test_oM and Test_Engine

### DIFF
--- a/.ci/code/UI_Test/Helpers/InstantiateCaller.cs
+++ b/.ci/code/UI_Test/Helpers/InstantiateCaller.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/.ci/code/UI_Test/Helpers/PossibleComponentItems.cs
+++ b/.ci/code/UI_Test/Helpers/PossibleComponentItems.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/.ci/code/UI_Test/Objects/DummyAccessor.cs
+++ b/.ci/code/UI_Test/Objects/DummyAccessor.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/.ci/code/UI_Test/Objects/DummyCaller.cs
+++ b/.ci/code/UI_Test/Objects/DummyCaller.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/.ci/code/UI_Test/Verify/ComponentInstantiation.cs
+++ b/.ci/code/UI_Test/Verify/ComponentInstantiation.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/.ci/code/UI_Test/Verify/ComponentReadWriteCycle.cs
+++ b/.ci/code/UI_Test/Verify/ComponentReadWriteCycle.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/.ci/code/UI_Test/Verify/ComponentRunCycle.cs
+++ b/.ci/code/UI_Test/Verify/ComponentRunCycle.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/UI_Engine/Query/Items.cs
+++ b/UI_Engine/Query/Items.cs
@@ -22,6 +22,7 @@
 
 using BH.Adapter;
 using BH.Engine.Reflection;
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -128,7 +129,7 @@ namespace BH.Engine.UI
         public static IEnumerable<Type> ConstructableTypeItems()
         {
             return Engine.Reflection.Query.BHoMTypeList()
-                .Where(x => x != null && !x.IsNotImplemented() && !x.IsDeprecated() && x.IsAutoConstructorAllowed() && !x.IsEnum && !x.IsAbstract && !x.FullName.Contains("+<>c"))
+                .Where(x => x != null && !x.IsNotImplemented() && !x.IsDeprecated() && x.IsAutoConstructorAllowed() && !x.IsEnum && !x.IsAbstract)
                 .Where(x => x.GetConstructors().Where(c => c.GetParameters().Count() > 0).Count() == 0);
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #363

As per title. also mirror the changes that were made on the script testing BHoM_UI

### Test files
You can simply call `.\TestRunner.exe UI` but I find there is still a few too many errors for this to be easily readable at the moment.
So I used this as well: https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_UI/CICD-%23363-AlignToTestToolkitChanges/TestRunner_UI.gh?csf=1&web=1&e=yRqvAl

This basically is a bunch of C# components that  call directly the tests inside UI_Test.dll. Since those return a `TestResult` it is easy to do a few explodes to get exactly the data you want out of it.


### Additional comments
Right now, here's the errors that I have. 

#### SetItem

```
BH.oM.Adapters.Sharepoint.Requests.AndCondition.AndCondition() {String Name, List<ICondition> Conditions}
BH.oM.Adapters.Sharepoint.Requests.BeginsWithCondition.BeginsWithCondition() {String Name, String Field, String Value}
BH.oM.Adapters.Sharepoint.Requests.ContainsCondition.ContainsCondition() {String Name, String Field, String Value}
BH.oM.Adapters.Sharepoint.Requests.EqualCondition.EqualCondition() {String Name, String Field, Object Value}
BH.oM.Adapters.Sharepoint.Requests.GreaterCondition.GreaterCondition() {String Name, String Field, Double Value}
BH.oM.Adapters.Sharepoint.Requests.GreaterEqualCondition.GreaterEqualCondition() {String Name, String Field, Double Value}
BH.oM.Adapters.Sharepoint.Requests.LessCondition.LessCondition() {String Name, String Field, Double Value}
BH.oM.Adapters.Sharepoint.Requests.LessEqualCondition.LessEqualCondition() {String Name, String Field, Double Value}
BH.oM.Adapters.Sharepoint.Requests.NotEqualCondition.NotEqualCondition() {String Name, String Field, Object Value}
BH.oM.Adapters.Sharepoint.Requests.OrCondition.OrCondition() {String Name, List<ICondition> Conditions}
```

Issue was already raised for those

#### Copy (without items from  above)

```
BH.Engine.Adapter.Query.AdapterId(IBHoMObject bHoMObject, Type adapterIdFragmentType)
```

Issue was already raised for that one too

#### Run (without items from  above)

```
BH.Engine.Adapters.File.Modify.ProcessFileDirRequest(FileDirRequest fdr, WildcardPattern& wildcardPattern)
BH.Engine.Adapters.File.Query.TryGetRegexFromPath(String fullPath, Regex& regex)
BH.Engine.Adapters.Plaxis.Convert.SinglePointLoadToPlaxis(PointLoad load, Int32& index)
BH.Engine.Adapters.Sharepoint.Query.TryGetUriExtension(String uri, String& extension)
BH.Engine.Base.Query.TryGetValue(FragmentSet fragmentSet, Type fragmentType, IFragment& fragment)
BH.Engine.Diffing.Convert.TryParseObjectToGuid(Object obj, Guid& guid)
BH.Engine.Geometry.Query.AreaIntegration(List<IntegrationSlice> slices, Double curve, Double from, Double to, Double& centroid)
BH.Engine.Geometry.Query.AreaIntegration(List<IntegrationSlice> slices, Vector direction, ICurve curve, Double from, Double to, Double& centroid)
BH.Engine.Geometry.Query.AreaIntegration(List<IntegrationSlice> solid, List<IntegrationSlice> voids, Vector direction, ICurve curve, Double from, Double to, and 1 more inputs)
BH.Engine.Geometry.Query.CurveIntegration(ICurve fx, Vector direction, Double from, Double to, Double& centroid, Double increment)
BH.Engine.Representation.Query.TryGetRendermesh(IBHoMObject bHoMObject, RenderMesh& renderMesh)
BH.Engine.Test.CodeCompliance.Query.ContainsToken(SyntaxTokenList list, String value)
BH.Engine.Test.CodeCompliance.Query.HasValidCopyright(SyntaxTriviaList leadingTrivia, Int32 year, String filePath)
BH.Engine.Test.CodeCompliance.Query.IsValidBHoMObject(SyntaxTriviaList leadingTrivia, String copyrightStatement)
BH.Engine.UI.Query.MatchWith(List<ParamInfo> newList, List<ParamInfo> oldList, List`1& added, List`1& removed)
```

no issue raised yet but given the errors we get from the TestResults, it is pretty clear they are mainly due to one issue with ref/out parameters not being handle properly on all levels:

```
Expression of type 'Microsoft.CodeAnalysis.SyntaxTokenList' cannot be used for return type 'System.Object'
Expression of type 'Microsoft.CodeAnalysis.SyntaxTriviaList' cannot be used for return type 'System.Object'
The type 'BH.oM.Base.IFragment&' may not be used as a type argument.
The type 'BH.oM.Graphics.RenderMesh&' may not be used as a type argument.
The type 'System.Collections.Generic.List`1[BH.oM.UI.ParamInfo]&' may not be used as a type argument.
The type 'System.Double&' may not be used as a type argument.
The type 'System.Guid&' may not be used as a type argument.
The type 'System.Int32&' may not be used as a type argument.
The type 'System.Management.Automation.WildcardPattern&' may not be used as a type argument.
The type 'System.String&' may not be used as a type argument.
The type 'System.Text.RegularExpressions.Regex&' may not be used as a type argument.
```

(not too sure what's going on with first two though). I will look into those next week but this is proof that those tests are doing their job. So I am happy with this PR 😄 