### PR TITLE
Fix failing components for methods with ref, out, or structure parameters

### DIFF
--- a/UI_Engine/Create/ParamInfo.cs
+++ b/UI_Engine/Create/ParamInfo.cs
@@ -82,10 +82,14 @@ namespace BH.Engine.UI
         [Output("parameter", "The bhom parameter used in the bhom abstract syntax")]
         public static ParamInfo ParamInfo(this ParameterInfo parameter, string description = "")
         {
+            Type paramType = parameter.ParameterType;
+            if (paramType.IsByRef && paramType.HasElementType)
+                paramType = paramType.GetElementType();
+
             return new ParamInfo
             {
                 Name = parameter.Name,
-                DataType = parameter.ParameterType,
+                DataType = paramType,
                 Description = description,
                 Kind = ParamKind.Input,
                 HasDefaultValue = parameter.HasDefaultValue,


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #368

See issue for more details.


### Test files
`./TestRunnre.exe UI`


### Additional comments
- Note that methods with a out input are now working BUT the out parameter is still an input, not an output. There is a separate issue for that here: https://github.com/BHoM/BHoM_UI/issues/313
- I recommend testing with the PR on SharePoint that fixes some invalid object to reduce the amount of noise you getting in the results of TestRunner
- Personally, I now get this resut from the testRunner:

```
PS C:\ProgramData\BHoM\Assemblies> .\TestRunner.exe UI

Testing input and output handling of the 7157 available BHoM components.
0 errors and 0 warnings reported.

Testing copy of the 7157 available BHoM components.
4 errors and 0 warnings reported.
Inner results:
        BH.Engine.Adapter.Query.AdapterId(IBHoMObject bHoMObject, Type adapterIdFragmentType)
        Error: Incorrect copy of BH.Engine.Adapter.Query.AdapterId(IBHoMObject bHoMObject, Type adapterIdFragmentType).
        BH.Engine.Rhinoceros.Convert.FromRhino(Object geometry)
        Error: Incorrect copy of BH.Engine.Rhinoceros.Convert.FromRhino(Object geometry).
        Inner results:
                Method IFromRhino from { "_t" : "System.Type", "Name" : "BH.Engine.Rhinoceros.Convert, Rhinoceros_Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null" } failed to deserialise.
        BH.Engine.Rhinoceros.Convert.FromRhino(Object obj)
        Error: Incorrect copy of BH.Engine.Rhinoceros.Convert.FromRhino(Object obj).
        Inner results:
                Method FromRhino from { "_t" : "System.Type", "Name" : "BH.Engine.Rhinoceros.Convert, Rhinoceros_Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null" } failed to deserialise.
        BH.Engine.Rhinoceros.Convert.ToRhino(CompositeGeometry geometries)
        Error: Incorrect copy of BH.Engine.Rhinoceros.Convert.ToRhino(CompositeGeometry geometries).
        Inner results:
                Method ToRhino from { "_t" : "System.Type", "Name" : "BH.Engine.Rhinoceros.Convert, Rhinoceros_Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null" } failed to deserialise.
                BH.UI.Base.Components.ConvertCaller failed to deserialise itself.

Testing instantiation of the 7157 available BHoM components.
0 errors and 0 warnings reported.
```

The Rhino stuff is working when tested in Grasshopper as it is just a question of missing referenced dlls. I'll add the exception to the UI verification later.