### PR TITLE
Better control when input parameters can be upgraded by the user

### DIFF
--- a/BHoM_UI/Caller/IO_CRUD.cs
+++ b/BHoM_UI/Caller/IO_CRUD.cs
@@ -77,7 +77,7 @@ namespace BH.UI.Base
 
         public virtual bool UpdateInput(int index, string name = null, Type type = null)
         {
-            if (index < 0)
+            if (index < 0 || !CanUpdateInput(index, name))
                 return false;
 
             if (InputParams.Count <= index)
@@ -182,6 +182,13 @@ namespace BH.UI.Base
                 ParamInfo match = OutputParams.Find(x => x.Name == name);
                 return match != null && !match.IsRequired;
             }
+        }
+
+        /*************************************/
+
+        public virtual bool CanUpdateInput(int index, string name)
+        {
+            return false;
         }
 
         /*************************************/

--- a/BHoM_UI/Components/Engine/SetProperty.cs
+++ b/BHoM_UI/Components/Engine/SetProperty.cs
@@ -115,14 +115,6 @@ namespace BH.UI.Base.Components
             return base.Run(inputs);
         }
 
-        /*************************************/
-
-        public override bool UpdateInput(int index, string name, Type type = null)
-        {
-            // Do not let update input types (they are detected automatically in CollectInputs())
-            return true;
-        }
-
 
         /*************************************/
         /**** Private Fields              ****/

--- a/BHoM_UI/Components/oM/CreateCustom.cs
+++ b/BHoM_UI/Components/oM/CreateCustom.cs
@@ -106,6 +106,13 @@ namespace BH.UI.Base.Components
 
         /*************************************/
 
+        public override bool CanUpdateInput(int index, string name)
+        {
+            return m_DynamicInputs;
+        }
+
+        /*************************************/
+
         public override bool RemoveInput(string name)
         {
             if (!m_DynamicInputs || name == null)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #351 

Up until now BHoM_UI was trusting individual UIs (GH, Excel,...) to only request an input update when it was necessary but it seems that Grasshopper was a bit to eager to request upgrades even when just a wire was connected to that input (i.e. no input menu interaction from the user). Since only the `CreateCustom` component actually allows update from the user, I set up the default to ignore any request from the UIs. (`SetProperty` and Explode where already doing their own thing without the need for user input).

In the case of the test file provided, Grasshopper was handling the positions as objects and not decimals and requesting BHoM_UI to change to that type. I have created a [separate issue](https://github.com/BHoM/Grasshopper_Toolkit/issues/605) to look into what Grasshopper is doing in more details but this PR fixes the problem raised in #351 

### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/Archive/BHoM_Engine/Graphics_Engine/Issue1343%20Base%20Gradient%20Methods/Issue1342%20Base%20Gradient%20Methods.gh?csf=1&web=1&e=2ttAtL

