### PR TITLE
Remove backslash from Descriptions

### DIFF
--- a/UI_Engine/Compute/SaveSettings.cs
+++ b/UI_Engine/Compute/SaveSettings.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.UI
         /**** Public Methods              ****/
         /*************************************/
 
-        [Description(@"Saves the settings for a toolkit into C:\ProgramData\BHoM\Settings. If Any previoulsy saved settings for that toolkit will be overwritten")]
+        [Description(@"Saves the settings for a toolkit into C:/ProgramData/BHoM/Settings. If Any previoulsy saved settings for that toolkit will be overwritten")]
         [Input("settings", "Settings for a toolkit that need to be saved permanently.")]
         [Output("success", "Returns true if the settings were saved successfully.")]
         public static bool SaveSettings(ISettings settings)

--- a/UI_Engine/Query/Settings.cs
+++ b/UI_Engine/Query/Settings.cs
@@ -39,9 +39,9 @@ namespace BH.Engine.UI
         /**** Public Methods              ****/
         /*************************************/
 
-        [Description(@"Extract settings of a given type from C:\ProgramData\BHoM\Settings")]
+        [Description(@"Extract settings of a given type from C:/ProgramData/BHoM/Settings")]
         [Input("type", "Object type of the settings you want to recover")]
-        [Output("settings", @"Settings recovered from the corresponding file in C:\ProgramData\BHoM\Settings")]
+        [Output("settings", @"Settings recovered from the corresponding file in C:/ProgramData/BHoM/Settings")]
         public static ISettings Settings(Type type)
         {
             if (type == null)
@@ -64,9 +64,9 @@ namespace BH.Engine.UI
 
         /*************************************/
 
-        [Description(@"Extract settings for a given toolkit from C:\ProgramData\BHoM\Settings")]
+        [Description(@"Extract settings for a given toolkit from C:/ProgramData/BHoM/Settings")]
         [Input("toolkitName", "Toolkit you want to recover the settings for")]
-        [Output("settings", @"Settings recovered from the corresponding file in C:\ProgramData\BHoM\Settings")]
+        [Output("settings", @"Settings recovered from the corresponding file in C:/ProgramData/BHoM/Settings")]
         public static ISettings Settings(string toolkitName)
         {
             // Make sure the file exists


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #312

`\` are now replace with `/` to keep the API happy. 

Note that I couldn't find any `\` in `BH.oM.UI.ISettings` but have fixed the other two files listed in the issue.