### PR TITLE
Provide user feedback for empty string on Set Project ID

### DIFF
--- a/UI_Engine/Compute/SetProjectID.cs
+++ b/UI_Engine/Compute/SetProjectID.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.UI
                 
             Engine.Reflection.Compute.RecordEvent(new ProjectIDEvent
             {
-                Message = "The project code for this file is now set to " + projectID,
+                Message = "The project ID for this file is now set to " + projectID,
                 ProjectID = projectID
             });
 

--- a/UI_Engine/Compute/SetProjectID.cs
+++ b/UI_Engine/Compute/SetProjectID.cs
@@ -45,8 +45,11 @@ namespace BH.Engine.UI
         public static bool SetProjectID(string projectID)
         {
             if (projectID == "")
+            {
+                Engine.Reflection.Compute.RecordWarning("Please enter the project number your work in this script relates to");
                 return false;
-
+            }
+                
             Engine.Reflection.Compute.RecordEvent(new ProjectIDEvent
             {
                 Message = "The project code for this file is now set to " + projectID,


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #378 

<!-- Add short description of what has been fixed -->
A warning message has now been provided to the user for the case of providing an empty string as input into the `SetProjectID` component.

Expected behaviour in Grasshopper is now

![image](https://user-images.githubusercontent.com/15924573/110375255-a4c0d180-8049-11eb-8f91-00f4c779482a.png)




### Test files
<!-- Link to test files to validate the proposed changes -->

Test using the `SetProjectID` with inputs of either an empty string or a valid ID to check correct messages occur. See expected new behaviour above. 