### PR TITLE
UI_Engine: Add versioning for LogUsage

### DIFF
--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -22,6 +22,7 @@
 
 using BH.Engine.Serialiser;
 using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
 using BH.oM.Reflection.Debugging;
 using BH.oM.UI;
 using System;
@@ -41,6 +42,7 @@ namespace BH.Engine.UI
         /**** Public Methods              ****/
         /*************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.UI.Compute.LogUsage(System.String, System.String, System.Guid, System.String, System.Object, System.Collections.Generic.List<BH.oM.Reflection.Debugging.Event>)")]
         public static void LogUsage(string uiName, string uiVersion, Guid componentId, string callerName, object selectedItem, List<Event> events = null, string fileId = "", string fileName = "")
         {
             // If a projectID event is available, save the project code for this file


### PR DESCRIPTION
Closes #382

Two arguments were added to the LogUsage method in [this PR](https://github.com/BHoM/BHoM_UI/pull/370). Since this is a public Engine method, it should have provided versioning.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_UI/%23282-LogUsageVersioning?csf=1&web=1&e=SixCyu

`LogUsage` should not appear in the list of failing methods

Alternatively, you can just pass this to a `FromJson` component and make sure it deserialise correctly:

```
{ "_t" : "System.Reflection.MethodBase", "TypeName" : "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.UI.Compute, UI_Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null\" }", "MethodName" : "LogUsage", "Parameters" : ["{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }", "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }", "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Guid, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }", "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }", "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }", "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Reflection.Debugging.Event\" }] }"] }
```

