### PR TITLE
Set .NET framework version to 4.5.2

### DIFF
--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.UI</RootNamespace>
     <AssemblyName>BHoM_UI</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -45,14 +45,6 @@
     </Reference>
     <Reference Include="BHoM_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="CSharp_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\CSharp_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="CSharp_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\CSharp_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_Engine">


### PR DESCRIPTION
### Issues addressed by this PR
Set the .NET framework version of the projects in this toolkit to 4.5.2

### Test files
This PR will be reviewed by making sure that an installer can be produced from it. 