### PR TITLE
Adding link to source for CreateDataCaller

### DIFF
--- a/BHoM_UI/Components/oM/CreateData.cs
+++ b/BHoM_UI/Components/oM/CreateData.cs
@@ -34,6 +34,7 @@ using BH.Engine.Data;
 using BH.Engine.Serialiser;
 using System.Windows.Forms;
 using BH.oM.Base;
+using System.Windows;
 
 namespace BH.UI.Base.Components
 {
@@ -98,6 +99,44 @@ namespace BH.UI.Base.Components
         public override List<string> GetChoiceNames()
         {
             return Choices.Cast<IBHoMObject>().Select(x => x.Name).ToList();
+        }
+
+        /*************************************/
+
+        public override void AddToMenu(ToolStripDropDown menu)
+        {
+            base.AddToMenu(menu);
+
+            if (FileName != null)
+            {
+                string sourceLink = Engine.Library.Query.Source(FileName)?.First()?.SourceLink;
+                if (!string.IsNullOrWhiteSpace(sourceLink))
+                {
+                    ToolStripLabel linkLabel = new ToolStripLabel("Source link");
+                    linkLabel.IsLink = true;
+                    linkLabel.Click += (object sender, EventArgs e) => System.Diagnostics.Process.Start(sourceLink);
+                    menu.Items.Add(linkLabel);
+                }
+            }
+        }
+
+        /*************************************/
+
+        public override void AddToMenu(System.Windows.Controls.ContextMenu menu)
+        {
+            base.AddToMenu(menu);
+
+            if (FileName != null)
+            {
+                string sourceLink = Engine.Library.Query.Source(FileName)?.First()?.SourceLink;
+                if (!string.IsNullOrWhiteSpace(sourceLink))
+                {
+                    System.Windows.Controls.MenuItem linkLabel = new System.Windows.Controls.MenuItem();
+                    linkLabel.Header = "Source Link";
+                    linkLabel.Click += (object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(sourceLink);
+                    menu.Items.Add(linkLabel);
+                }
+            }
         }
 
         /*************************************/

--- a/BHoM_UI/Components/oM/CreateData.cs
+++ b/BHoM_UI/Components/oM/CreateData.cs
@@ -91,8 +91,8 @@ namespace BH.UI.Base.Components
                 Choices = BH.Engine.Library.Query.Library(FileName).ToList<object>();
                 Name = FileName.Split(new char[] { '\\' }).Last();
                 Description = BH.Engine.Library.Query.SourceAndDisclaimer(FileName);
-                if (m_menu != null)
-                    AddSourceLinkToMenu(m_menu as dynamic);
+                if (m_Menu != null)
+                    AddSourceLinkToMenu(m_Menu as dynamic);
             }
         }
 
@@ -108,7 +108,7 @@ namespace BH.UI.Base.Components
         public override void AddToMenu(object menu)
         {
             base.AddToMenu(menu);
-            m_menu = menu;  //Store the menu to be able to add source link in case of presistent menu
+            m_Menu = menu;  //Store the menu to be able to add source link in case of presistent menu
             AddSourceLinkToMenu(menu as dynamic);  //Try add link now for volatile menu
         }
 
@@ -161,7 +161,7 @@ namespace BH.UI.Base.Components
         /**** Private fields              ****/
         /*************************************/
 
-        private object m_menu = null;
+        private object m_Menu = null;
 
         /*************************************/
     }

--- a/BHoM_UI/Components/oM/CreateData.cs
+++ b/BHoM_UI/Components/oM/CreateData.cs
@@ -91,6 +91,8 @@ namespace BH.UI.Base.Components
                 Choices = BH.Engine.Library.Query.Library(FileName).ToList<object>();
                 Name = FileName.Split(new char[] { '\\' }).Last();
                 Description = BH.Engine.Library.Query.SourceAndDisclaimer(FileName);
+                if (m_menu != null)
+                    AddSourceLinkToMenu(m_menu as dynamic);
             }
         }
 
@@ -103,16 +105,26 @@ namespace BH.UI.Base.Components
 
         /*************************************/
 
-        public override void AddToMenu(ToolStripDropDown menu)
+        public override void AddToMenu(object menu)
         {
             base.AddToMenu(menu);
+            m_menu = menu;  //Store the menu to be able to add source link in case of presistent menu
+            AddSourceLinkToMenu(menu as dynamic);  //Try add link now for volatile menu
+        }
 
-            if (FileName != null)
+        /*************************************/
+        /**** Private methods             ****/
+        /*************************************/
+
+        private void AddSourceLinkToMenu(ToolStripDropDown menu)
+        {
+            if (FileName != null && !menu.Items.ContainsKey("SourceLink"))
             {
                 string sourceLink = Engine.Library.Query.Source(FileName)?.First()?.SourceLink;
                 if (!string.IsNullOrWhiteSpace(sourceLink))
                 {
                     ToolStripLabel linkLabel = new ToolStripLabel("Source link");
+                    linkLabel.Name = "SourceLink";
                     linkLabel.IsLink = true;
                     linkLabel.Click += (object sender, EventArgs e) => System.Diagnostics.Process.Start(sourceLink);
                     menu.Items.Add(linkLabel);
@@ -122,22 +134,34 @@ namespace BH.UI.Base.Components
 
         /*************************************/
 
-        public override void AddToMenu(System.Windows.Controls.ContextMenu menu)
+        private void AddSourceLinkToMenu(System.Windows.Controls.ContextMenu menu)
         {
-            base.AddToMenu(menu);
-
-            if (FileName != null)
+            if (FileName != null && !menu.Items.SourceCollection.OfType<MenuItem>().Any(x => x.Name == "SourceLink"))
             {
                 string sourceLink = Engine.Library.Query.Source(FileName)?.First()?.SourceLink;
                 if (!string.IsNullOrWhiteSpace(sourceLink))
                 {
                     System.Windows.Controls.MenuItem linkLabel = new System.Windows.Controls.MenuItem();
                     linkLabel.Header = "Source Link";
+                    linkLabel.Name = "SourceLink";
                     linkLabel.Click += (object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(sourceLink);
                     menu.Items.Add(linkLabel);
                 }
             }
         }
+
+        /*************************************/
+
+        private void AddSourceLinkToMenu(object menu)
+        {
+            //fallback method
+        }
+
+        /*************************************/
+        /**** Private fields              ****/
+        /*************************************/
+
+        private object m_menu = null;
 
         /*************************************/
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #400 

<!-- Add short description of what has been fixed -->

Checking if the dataset contains a SourceLink, and if so, add a link to it in the menu. Really useful to have quick direct access to the source of the data, when available.

Added the functionality for both the Toolstrip and WPF, but was not able to test the WPF as I do not know where it is being called from. Tried in dynamo, but looked as if the menu is only triggered once, when you add the component, and not again when a dataset has been selected. Happy to remove the WPF implementation if we think that is a better way to go.

### Test files
<!-- Link to test files to validate the proposed changes -->

Any of the UK steelsection or EU material datasets should have working links:

![image](https://user-images.githubusercontent.com/22005920/131095067-b2d1df30-167e-4019-ab2f-4e62ae75e1a7.png)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->