### PR TITLE
Ability to save and load ISettings to and from chosen file paths added

### DIFF
--- a/UI_Engine/Compute/ReadSettingsFromFile.cs
+++ b/UI_Engine/Compute/ReadSettingsFromFile.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/UI_Engine/Compute/ReadSettingsFromFile.cs
+++ b/UI_Engine/Compute/ReadSettingsFromFile.cs
@@ -1,6 +1,6 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -20,56 +20,52 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Reflection;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
-using BH.oM.UI;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 
 namespace BH.Engine.UI
 {
-    public static partial class Query
+    public static partial class Compute
     {
         /*************************************/
         /**** Public Methods              ****/
         /*************************************/
 
-        [Description(@"Extract settings of a given type from C:/ProgramData/BHoM/Settings")]
-        [Input("type", "Object type of the settings you want to recover")]
-        [Output("settings", @"Settings recovered from the corresponding file in C:/ProgramData/BHoM/Settings")]
-        public static ISettings Settings(this Type type)
+        [Description("Reads BHoM toolkit settings from a file under given path.")]
+        [Input("filePath", "Path to the file to extract the settings from.")]
+        [Output("settings", "BHoM toolkit settings extracted from the input file path.")]
+        public static ISettings ReadSettingsFromFile(this string filePath)
         {
-            if (type == null)
+            // Make sure the file exists
+            if (!File.Exists(filePath))
             {
-                Engine.Reflection.Compute.RecordError("Settings type is null.");
+                Engine.Reflection.Compute.RecordWarning($"Settings file does not exits under path {filePath}.");
                 return null;
             }
 
-            // Get the config file name
-            string[] splittedNamespace = type.Namespace.Split(new char[] { '.' });
-            if (splittedNamespace.Length != 3)
+            // Get the json out of the file
+            string json = "";
+            try
             {
-                Engine.Reflection.Compute.RecordError("This settings object doesn't have a valid namespace. It should be `BH.oM.ToolkitName` .");
+                json = File.ReadAllText(filePath);
+            }
+            catch
+            {
+                Reflection.Compute.RecordError($"Settings could not be read from the file under path {filePath}. Please make sure it isn't locked by another program.");
                 return null;
             }
 
-            string toolkitName = splittedNamespace[2];
-            return Settings(toolkitName);
-        }
-
-        /*************************************/
-
-        [Description(@"Extract settings for a given toolkit from C:/ProgramData/BHoM/Settings")]
-        [Input("toolkitName", "Toolkit you want to recover the settings for")]
-        [Output("settings", @"Settings recovered from the corresponding file in C:/ProgramData/BHoM/Settings")]
-        public static ISettings Settings(this string toolkitName)
-        {
-            string filePath = Path.Combine(@"C:\ProgramData\BHoM\Settings", toolkitName + ".cfg");
-            return Compute.ReadSettingsFromFile(filePath);
+            // Convert back into a Settings object
+            object settings = Engine.Serialiser.Convert.FromJson(json);
+            if (settings is ISettings)
+                return settings as ISettings;
+            else
+            {
+                Reflection.Compute.RecordError("The content of the file" + filePath + " doesn't contain a valid ISettings object.");
+                return null;
+            }
         }
 
         /*************************************/

--- a/UI_Engine/Compute/SaveSettings.cs
+++ b/UI_Engine/Compute/SaveSettings.cs
@@ -29,8 +29,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 
 namespace BH.Engine.UI
 {
@@ -40,27 +38,33 @@ namespace BH.Engine.UI
         /**** Public Methods              ****/
         /*************************************/
 
-        [Description(@"Saves the settings for a toolkit into C:/ProgramData/BHoM/Settings. If Any previoulsy saved settings for that toolkit will be overwritten")]
-        [Input("settings", "Settings for a toolkit that need to be saved permanently.")]
+        [PreviousVersion("BH.Engine.UI.Compute.SaveSettings(BH.oM.Base.ISettings)")]
+        [Description("Saves toolkit settings into a given path. If no path is provided, the settings will be saved to C:/ProgramData/BHoM/Settings/{ToolkitName}. Any previously saved settings under given path will be overwritten.")]
+        [Input("settings", "Toolkit settings to be saved to the file.")]
+        [Input("filePath", "File path to save the settings to. If left blank, the settings will be saved to C:/ProgramData/BHoM/Settings/{ToolkitName}.")]
         [Output("success", "Returns true if the settings were saved successfully.")]
-        public static bool SaveSettings(ISettings settings)
+        public static bool SaveSettings(this ISettings settings, string filePath = "")
         {
             if (settings == null)
             {
                 Engine.Reflection.Compute.RecordError("Settings object is null.");
                 return false;
             }
-                
-            // Get the config file name
-            string[] splittedNamespace = settings.GetType().Namespace.Split(new char[] { '.' });
-            if (splittedNamespace.Length != 3)
-            {
-                Engine.Reflection.Compute.RecordError("This settings object doesn't have a valid namespace. It should be `BH.oM.ToolkitName` .");
-                return false;
-            }
 
-            string toolkitName = splittedNamespace[2];
-            string filePath = Path.Combine(@"C:\ProgramData\BHoM\Settings", toolkitName + ".cfg");
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                // Get the config file name
+                string[] splittedNamespace = settings.GetType().Namespace.Split(new char[] { '.' });
+                if (splittedNamespace.Length != 3)
+                {
+                    Engine.Reflection.Compute.RecordError("This settings object doesn't have a valid namespace. It should be `BH.oM.ToolkitName` .");
+                    return false;
+                }
+
+                string toolkitName = splittedNamespace[2];
+                filePath = Path.Combine(@"C:\ProgramData\BHoM\Settings", toolkitName + ".cfg");
+                BH.Engine.Reflection.Compute.RecordNote($"Settings have been saved to the default location: {filePath}");
+            }
 
             // Save the setting in that file
             File.WriteAllText(filePath, settings.ToJson());
@@ -71,6 +75,3 @@ namespace BH.Engine.UI
         /*************************************/
     }
 }
-
-
-

--- a/UI_Engine/Compute/SaveSettings.cs
+++ b/UI_Engine/Compute/SaveSettings.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.UI
         /**** Public Methods              ****/
         /*************************************/
 
-        [PreviousVersion("BH.Engine.UI.Compute.SaveSettings(BH.oM.Base.ISettings)")]
+        [PreviousVersion("5.1", "BH.Engine.UI.Compute.SaveSettings(BH.oM.Base.ISettings)")]
         [Description("Saves toolkit settings into a given path. If no path is provided, the settings will be saved to C:/ProgramData/BHoM/Settings/{ToolkitName}. Any previously saved settings under given path will be overwritten.")]
         [Input("settings", "Toolkit settings to be saved to the file.")]
         [Input("filePath", "File path to save the settings to. If left blank, the settings will be saved to C:/ProgramData/BHoM/Settings/{ToolkitName}.")]

--- a/UI_Engine/UI_Engine.csproj
+++ b/UI_Engine/UI_Engine.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BHoM">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -40,14 +41,17 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Engine">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_Engine">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_oM">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -57,16 +61,19 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Serialiser_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/UI_Engine/UI_Engine.csproj
+++ b/UI_Engine/UI_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -78,6 +78,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\ReadSettingsFromFile.cs" />
     <Compile Include="Compute\RecordError.cs" />
     <Compile Include="Compute\SetProjectID.cs" />
     <Compile Include="Compute\SaveSettings.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #411

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FUI%2F%23412%2DIRevitSettingsOnButtonsAndAddins&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
The change of signature in `SaveSettings` does not change the original behaviour without the extra parameter.