### PR TITLE
Improve `Explode` component behaviour when object has some non-retrievable properties

### DIFF
--- a/BHoM_UI/Components/Engine/Explode.cs
+++ b/BHoM_UI/Components/Engine/Explode.cs
@@ -86,7 +86,23 @@ namespace BH.UI.Base.Components
                 if (obj == null)
                     return Enumerable.Repeat<object>(null, m_CompiledSetters.Count).ToList();
 
-                List<object> result = OutputParams.Select(x => obj.PropertyValue(x.Name)).ToList();
+                List<object> result = new List<object>();
+
+                foreach (var x in OutputParams)
+                {
+                    object propValue = null;
+                    try
+                    {
+                        propValue = obj.PropertyValue(x.Name);
+                    }
+                    catch
+                    {
+                        Engine.Base.Compute.RecordWarning($"Value of the property `{x.Name}` could not be retrieved.");
+                    }
+
+                    result.Add(propValue);
+                }
+
                 return (result.Count == 1) ? result[0] : result;
             }
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #423 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See #423 for the test script.

Before this PR, the script will return an error on the Explode component, returning no output (not even for the retrievable properties).
After this PR, the script should behave as this:
![image](https://user-images.githubusercontent.com/6352844/183459826-0359afd2-b623-4de5-baf5-66223446625c.png)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->