### PR TITLE
Enum.GetNames replaced with IToText on enum label generation to leverage DisplayText attribute

### DIFF
--- a/BHoM_UI/Components/oM/CreateEnum.cs
+++ b/BHoM_UI/Components/oM/CreateEnum.cs
@@ -99,12 +99,7 @@ namespace BH.UI.Base.Components
         {
             List<string> names = new List<string>();
             if (EnumType != null)
-            {
-                foreach (var item in Enum.GetValues(EnumType))
-                {
-                    names.Add(item.IToText());
-                }
-            }
+                names.AddRange(Enum.GetValues(EnumType).OfType<Enum>().Select(x => x.IToText()));
 
             return names;
         }

--- a/BHoM_UI/Components/oM/CreateEnum.cs
+++ b/BHoM_UI/Components/oM/CreateEnum.cs
@@ -97,11 +97,10 @@ namespace BH.UI.Base.Components
 
         public override List<string> GetChoiceNames()
         {
-            List<string> names = new List<string>();
             if (EnumType != null)
-                names.AddRange(Enum.GetValues(EnumType).OfType<Enum>().Select(x => x.IToText()));
-
-            return names;
+                return Enum.GetValues(EnumType).OfType<Enum>().Select(x => x.ToText()).ToList();
+            else
+                return new List<string>();
         }
 
         /*************************************/

--- a/BHoM_UI/Components/oM/CreateEnum.cs
+++ b/BHoM_UI/Components/oM/CreateEnum.cs
@@ -33,6 +33,7 @@ using BH.Engine.Reflection;
 using BH.Engine.Data;
 using BH.Engine.Serialiser;
 using System.Windows.Forms;
+using BH.Engine.Base;
 
 namespace BH.UI.Base.Components
 {
@@ -96,10 +97,16 @@ namespace BH.UI.Base.Components
 
         public override List<string> GetChoiceNames()
         {
+            List<string> names = new List<string>();
             if (EnumType != null)
-                return Enum.GetNames(EnumType).ToList();
-            else
-                return new List<string>();
+            {
+                foreach (var item in Enum.GetValues(EnumType))
+                {
+                    names.Add(item.IToText());
+                }
+            }
+
+            return names;
         }
 
         /*************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #447

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Create `DensityExtractionType` enum in Grasshopper and see if the first option shows as `AllMatching` (current) or `All matching.` (desired).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->