### PR TITLE
Utilise Exposure in ParamInfo

### DIFF
--- a/BHoM_UI/Caller/SetInputs.cs
+++ b/BHoM_UI/Caller/SetInputs.cs
@@ -67,7 +67,7 @@ namespace BH.UI.Base
                     ParamInfo p = Engine.UI.Create.ParamInfo(x, descriptions.ContainsKey(x.Name) ? descriptions[x.Name] : "");
 
                     if (exposures.ContainsKey(x.Name) && exposures[x.Name] == UIExposure.Hidden)
-                        p.IsExposed = false;
+                        p.IsSelected = false;
 
                     PreviousInputNamesAttribute match = previousNames.FirstOrDefault(a => a.Name == p.Name);
                     if (match != null)

--- a/BHoM_UI/Caller/SetInputs.cs
+++ b/BHoM_UI/Caller/SetInputs.cs
@@ -33,6 +33,7 @@ using System.Windows.Forms;
 using System.Collections;
 using BH.Engine.UI;
 using BH.oM.Base.Attributes;
+using BH.oM.Base.Attributes.Enums;
 
 namespace BH.UI.Base
 {
@@ -60,9 +61,14 @@ namespace BH.UI.Base
             {
                 List< PreviousInputNamesAttribute> previousNames = method.GetCustomAttributes<PreviousInputNamesAttribute>().ToList();
                 Dictionary<string, string> descriptions = method.InputDescriptions();
+                Dictionary<string, UIExposure> exposures = method.InputExposure();
                 InputParams = method.GetParameters().Select(x =>
                 {
                     ParamInfo p = Engine.UI.Create.ParamInfo(x, descriptions.ContainsKey(x.Name) ? descriptions[x.Name] : "");
+
+                    if (exposures.ContainsKey(x.Name) && exposures[x.Name] == UIExposure.Hidden)
+                        p.IsExposed = false;
+
                     PreviousInputNamesAttribute match = previousNames.FirstOrDefault(a => a.Name == p.Name);
                     if (match != null)
                         p.Fragments.Add(new PreviousNamesFragment { OldNames = match.PreviousNames });

--- a/UI_oM/ParamInfo.cs
+++ b/UI_oM/ParamInfo.cs
@@ -51,6 +51,8 @@ namespace BH.oM.UI
 
         public virtual string DefaultValueWarning { get; set; } = "";
 
+        public virtual bool IsExposed { get; set; } = true;
+
         /***************************************************/
     }
 }

--- a/UI_oM/ParamInfo.cs
+++ b/UI_oM/ParamInfo.cs
@@ -51,8 +51,6 @@ namespace BH.oM.UI
 
         public virtual string DefaultValueWarning { get; set; } = "";
 
-        public virtual bool IsExposed { get; set; } = true;
-
         /***************************************************/
     }
 }


### PR DESCRIPTION
Fixes #455 

This provides the UIExposure information to the `ParamInfo` object used by all UIs downstream.

Each UI will be responsible for handling how they opt to display or not display something with `IsExposed = false` depending on each UIs requirements.