### PR TITLE
Solving the slow execution of CollectOutputTypes on Custom objects

### DIFF
--- a/UI_Engine/Query/OutputParams.cs
+++ b/UI_Engine/Query/OutputParams.cs
@@ -148,7 +148,7 @@ namespace BH.Engine.UI
 
         private static void CollectOutputTypes(IEnumerable<CustomObject> objects, ref Dictionary<string, List<Type>> properties)
         {
-            foreach (KeyValuePair<string, object> prop in objects.SelectMany(x => x.CustomData).Distinct())
+            foreach (KeyValuePair<string, object> prop in objects.SelectMany(x => x.CustomData))
             {
                 if (!properties.ContainsKey(prop.Key))
                     properties[prop.Key] = new List<Type>();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #478 

### Test files
[ExplodeDeleteTest.zip](https://github.com/BHoM/BHoM_UI/files/13833322/ExplodeDeleteTest.zip)

The call to `OutputParams` was very slow (~20s) so I added it to the scrip to confirm in now takes only a few milliseconds. 

