### PR TITLE
Add ability to load settings

### DIFF
--- a/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml
+++ b/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml
@@ -48,9 +48,9 @@
                     <Setter Property="Padding" Value="2" />
                 </Style>
             </StackPanel.Resources>
-            <Button Name="SelectAllBtn" Content="Unselect all" Width="70" Background="#0DCAF0" Click="SelectAll"/>
-            <Button Content="Reset" Width="50" Background="#F0AD4E" Click="ResetAll" />
-            <Button Content="Save"  Width="50" Background="#5CB85C" Click="SaveAll "/>
+            <Button Name="SelectAllBtn" Content="Unselect all" Width="70" Background="#0DCAF0" Click="SelectAll" ToolTip="Clicking this will uncheck all toolkits currently selected."/>
+            <Button Content="Load" Width="50" Background="#F0AD4E" Click="LoadSettings" ToolTip="Select a settings file from your system to load in. You will have the chance to inspect those settings before they are used. You will need to hit the Save button to confirm those settings." />
+            <Button Content="Save"  Width="50" Background="#5CB85C" Click="SaveAll" ToolTip="Save the settings currently selected. This will export settings to your harddrive so they can be loaded again next time you use BHoM, as well as loaded into memory to take effect from the point you hit this button. The settings window will close once settings are saved."/>
         </StackPanel>
         
         <ScrollViewer Grid.Row="3" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden" Padding="2">

--- a/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
+++ b/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
@@ -151,11 +151,34 @@ namespace BH.UI.Base.Windows.Settings
 
         /*************************************/
 
-        private void ResetAll(object sender, EventArgs e)
+        private void LoadSettings(object sender, EventArgs e)
         {
-            m_ToolkitItems.ForEach(x => x.Include = true);
-            m_SelectAll = true;
-            SelectAllBtn.Content = "Unselect all";
+            Microsoft.Win32.OpenFileDialog openFileDlg = new Microsoft.Win32.OpenFileDialog();
+            openFileDlg.DefaultExt = ".json";
+            openFileDlg.Filter = "JSON Files (*json)|*json";
+
+            bool? result = openFileDlg.ShowDialog();
+            if (result.HasValue && result.Value)
+            {
+                var filePath = openFileDlg.FileName;
+                try
+                {
+                    BH.Engine.Settings.Compute.LoadSettings(filePath);
+                    var existingSettings = Query.GetSettings(typeof(BH.oM.UI.SearchSettings)) as SearchSettings;
+                    if (existingSettings != null)
+                    {
+                        m_Settings = existingSettings;
+                        existingSettings.Toolkits.ForEach(x =>
+                        {
+                            m_ToolkitItems.Where(y => y.Toolkit == x.Toolkit).FirstOrDefault().Include = x.Include;
+                        });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"An error occurred in loading that settings file. The error recorded was {ex.Message}. Settings have not been loaded.", "Error loading settings file.", MessageBoxButton.OK);
+                }
+            }
         }
 
         /*************************************/
@@ -175,9 +198,15 @@ namespace BH.UI.Base.Windows.Settings
             m_ToolkitItems.ForEach(x => x.Include = m_SelectAll);
 
             if (m_SelectAll)
+            {
                 SelectAllBtn.Content = "Unselect all";
+                SelectAllBtn.ToolTip = "Clicking this will uncheck all toolkits currently selected.";
+            }
             else
+            {
                 SelectAllBtn.Content = "Select all";
+                SelectAllBtn.ToolTip = "Clicking this will check all toolkits currently not selected.";
+            }
         }
 
         /*************************************/

--- a/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
+++ b/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
@@ -164,7 +164,10 @@ namespace BH.UI.Base.Windows.Settings
                 var filePath = openFileDlg.FileName;
                 try
                 {
+                    BH.Engine.Base.Compute.ThrowErrorsAsExceptions(true);
                     BH.Engine.Settings.Compute.LoadSettings(filePath);
+                    BH.Engine.Base.Compute.ThrowErrorsAsExceptions(false);
+
                     var existingSettings = Query.GetSettings(typeof(BH.oM.UI.SearchSettings)) as SearchSettings;
                     if (existingSettings != null)
                     {
@@ -188,6 +191,7 @@ namespace BH.UI.Base.Windows.Settings
                 catch (Exception ex)
                 {
                     MessageBox.Show($"An error occurred in loading that settings file. The error recorded was {ex.Message}. Settings have not been loaded.", "Error loading settings file.", MessageBoxButton.OK);
+                    BH.Engine.Base.Compute.ThrowErrorsAsExceptions(false); //Just in case - belt and braces
                 }
             }
         }

--- a/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
+++ b/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -170,8 +171,18 @@ namespace BH.UI.Base.Windows.Settings
                         m_Settings = existingSettings;
                         existingSettings.Toolkits.ForEach(x =>
                         {
-                            m_ToolkitItems.Where(y => y.Toolkit == x.Toolkit).FirstOrDefault().Include = x.Include;
+                            var item = m_ToolkitItems.Where(y => y.Toolkit == x.Toolkit).FirstOrDefault();
+                            if (item == null)
+                            {
+                                var newModel = new ToolkitSelectItemModel(x);
+                                ConvertToCheckbox(newModel);
+                                m_ToolkitItems.Add(newModel);
+                            }
+                            else
+                                item.Include = x.Include;
                         });
+
+                        m_ToolkitItems = m_ToolkitItems.OrderBy(x => x.Toolkit).ToList();
                     }
                 }
                 catch (Exception ex)

--- a/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
+++ b/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
@@ -190,7 +190,7 @@ namespace BH.UI.Base.Windows.Settings
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show($"An error occurred in loading that settings file. The error recorded was {ex.Message}. Settings have not been loaded.", "Error loading settings file.", MessageBoxButton.OK);
+                    MessageBox.Show($"An error occurred in loading that settings file. Settings have not been loaded. The error recorded was {ex.Message}", "Error loading settings file.", MessageBoxButton.OK);
                     BH.Engine.Base.Compute.ThrowErrorsAsExceptions(false); //Just in case - belt and braces
                 }
             }

--- a/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
+++ b/BHoM_Windows_UI/Settings/SearchSettingsWindow.xaml.cs
@@ -165,7 +165,7 @@ namespace BH.UI.Base.Windows.Settings
                 try
                 {
                     BH.Engine.Base.Compute.ThrowErrorsAsExceptions(true);
-                    BH.Engine.Settings.Compute.LoadSettings(filePath);
+                    BH.Engine.Settings.Compute.LoadSettingsFromFile(filePath);
                     BH.Engine.Base.Compute.ThrowErrorsAsExceptions(false);
 
                     var existingSettings = Query.GetSettings(typeof(BH.oM.UI.SearchSettings)) as SearchSettings;


### PR DESCRIPTION
### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/3300
https://github.com/BHoM/BHoM_Engine/pull/3302
https://github.com/BHoM/BHoM_Engine/pull/3304
   
### Issues addressed by this PR
Fixes #483 


### Test files
Same as #482 

Use this JSON file to load in and see what changes you get: 
[BH.oM.UI.SearchSettings.json](https://github.com/BHoM/BHoM_UI/files/14418386/BH.oM.UI.SearchSettings.json)

Try to break the JSON file and check you get errors as well.

You should find the first few alphabetical options are unchecked, and you should get a new addition of `ABCDEF` being checked - it will likely render at the bottom first but on a reload of the settings window you'll find it at the top.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
I have removed the `Reset` button because this was effectively duplicating the `Select/Unselect all` buttons, and it was only resetting to check everything rather than resetting to the originally loaded state or similar. Thus, with discussion with @Tom-Kingstone and @albinber this looked like it could cause a negative UX, so has been removed to avoid confusion.

Tooltips have been added to aid usability though.