### PR TITLE
Update run to reset log suppression after running component

### DIFF
--- a/BHoM_UI/Caller/Run.cs
+++ b/BHoM_UI/Caller/Run.cs
@@ -76,9 +76,16 @@ namespace BH.UI.Base
         {
             if (m_CompiledFunc != null)
             {
+                bool suppressingErrors = BH.Engine.Base.Query.IsSuppressingErrors();
+                bool suppressingWarnings = BH.Engine.Base.Query.IsSuppressingWarnings();
+                bool suppressingNotes = BH.Engine.Base.Query.IsSuppressingNotes();
+                bool throwingErrors = BH.Engine.Base.Query.IsThrowingErrors();
+
                 try
                 {
-                    return m_CompiledFunc(inputs.ToArray());
+                    var result = m_CompiledFunc(inputs.ToArray());
+                    ResetLogSuppression(suppressingErrors, suppressingWarnings, suppressingNotes, throwingErrors);
+                    return result;
                 }
                 catch (InvalidCastException e)
                 {
@@ -88,10 +95,15 @@ namespace BH.UI.Base
                         // Try to update the generic method to fit the input types
                         MethodInfo method = Engine.Base.Compute.MakeGenericFromInputs(originalMethod, inputs.Select(x => x?.GetType()).ToList());
                         m_CompiledFunc = method.ToFunc();
-                        return m_CompiledFunc(inputs.ToArray());
+                        var result = m_CompiledFunc(inputs.ToArray());
+                        ResetLogSuppression(suppressingErrors, suppressingWarnings, suppressingNotes, throwingErrors);
+                        return result;
                     }
                     else
+                    {
+                        ResetLogSuppression(suppressingErrors, suppressingWarnings, suppressingNotes, throwingErrors);
                         throw e;
+                    }
                 }
             }
             else if (InputParams.Count <= 0)
@@ -304,6 +316,15 @@ namespace BH.UI.Base
         protected virtual bool ShouldCalculateNewResult(List<object> inputs, ref object result)
         {
             return true;
+        }
+
+        /*************************************/
+
+        protected void ResetLogSuppression(bool suppressingErrors, bool suppressingWarnings, bool suppressingNotes, bool throwingErrors)
+        {
+            BH.Engine.Base.Compute.StopSuppressRecordingEvents(); //Ensure suppression is reset in case the calling method forgot to do it
+            BH.Engine.Base.Compute.StartSuppressRecordingEvents(suppressingErrors, suppressingWarnings, suppressingNotes); //Set the suppression back to what the user may have set it to prior to running this method
+            BH.Engine.Base.Compute.ThrowErrorsAsExceptions(throwingErrors); //Reset throwing errors to whatever the user may have set it to prior to running this method
         }
 
 

--- a/BHoM_UI/Caller/Run.cs
+++ b/BHoM_UI/Caller/Run.cs
@@ -76,15 +76,10 @@ namespace BH.UI.Base
         {
             if (m_CompiledFunc != null)
             {
-                bool suppressingErrors = BH.Engine.Base.Query.IsSuppressingErrors();
-                bool suppressingWarnings = BH.Engine.Base.Query.IsSuppressingWarnings();
-                bool suppressingNotes = BH.Engine.Base.Query.IsSuppressingNotes();
-                bool throwingErrors = BH.Engine.Base.Query.IsThrowingErrors();
-
                 try
                 {
                     var result = m_CompiledFunc(inputs.ToArray());
-                    ResetLogSuppression(suppressingErrors, suppressingWarnings, suppressingNotes, throwingErrors);
+                    BH.Engine.Base.Compute.StopSuppressRecordingEvents();
                     return result;
                 }
                 catch (InvalidCastException e)
@@ -96,12 +91,12 @@ namespace BH.UI.Base
                         MethodInfo method = Engine.Base.Compute.MakeGenericFromInputs(originalMethod, inputs.Select(x => x?.GetType()).ToList());
                         m_CompiledFunc = method.ToFunc();
                         var result = m_CompiledFunc(inputs.ToArray());
-                        ResetLogSuppression(suppressingErrors, suppressingWarnings, suppressingNotes, throwingErrors);
+                        BH.Engine.Base.Compute.StopSuppressRecordingEvents();
                         return result;
                     }
                     else
                     {
-                        ResetLogSuppression(suppressingErrors, suppressingWarnings, suppressingNotes, throwingErrors);
+                        BH.Engine.Base.Compute.StopSuppressRecordingEvents();
                         throw e;
                     }
                 }
@@ -317,16 +312,6 @@ namespace BH.UI.Base
         {
             return true;
         }
-
-        /*************************************/
-
-        protected void ResetLogSuppression(bool suppressingErrors, bool suppressingWarnings, bool suppressingNotes, bool throwingErrors)
-        {
-            BH.Engine.Base.Compute.StopSuppressRecordingEvents(); //Ensure suppression is reset in case the calling method forgot to do it
-            BH.Engine.Base.Compute.StartSuppressRecordingEvents(suppressingErrors, suppressingWarnings, suppressingNotes); //Set the suppression back to what the user may have set it to prior to running this method
-            BH.Engine.Base.Compute.ThrowErrorsAsExceptions(throwingErrors); //Reset throwing errors to whatever the user may have set it to prior to running this method
-        }
-
 
         /*************************************/
         /**** Private Fields              ****/

--- a/BHoM_UI/Caller/Run.cs
+++ b/BHoM_UI/Caller/Run.cs
@@ -79,7 +79,7 @@ namespace BH.UI.Base
                 try
                 {
                     var result = m_CompiledFunc(inputs.ToArray());
-                    BH.Engine.Base.Compute.StopSuppressRecordingEvents();
+                    ResetLogSuppression();
                     return result;
                 }
                 catch (InvalidCastException e)
@@ -91,12 +91,12 @@ namespace BH.UI.Base
                         MethodInfo method = Engine.Base.Compute.MakeGenericFromInputs(originalMethod, inputs.Select(x => x?.GetType()).ToList());
                         m_CompiledFunc = method.ToFunc();
                         var result = m_CompiledFunc(inputs.ToArray());
-                        BH.Engine.Base.Compute.StopSuppressRecordingEvents();
+                        ResetLogSuppression();
                         return result;
                     }
                     else
                     {
-                        BH.Engine.Base.Compute.StopSuppressRecordingEvents();
+                        ResetLogSuppression();
                         throw e;
                     }
                 }
@@ -312,6 +312,15 @@ namespace BH.UI.Base
         {
             return true;
         }
+
+        /*************************************/
+
+        protected void ResetLogSuppression()
+        {
+            BH.Engine.Base.Compute.StopSuppressRecordingEvents(); //Ensure suppression is reset in case the calling method forgot to do it
+            BH.Engine.Base.Compute.ThrowErrorsAsExceptions(false); //Reset throwing errors to whatever the user may have set it to prior to running this method
+        }
+
 
         /*************************************/
         /**** Private Fields              ****/


### PR DESCRIPTION
### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/3307

   
### Issues addressed by this PR
Fixes #485 

### Additional comments
You may be wondering why I've opted to query the suppression state to then reset it, however, the use case for this is if a user of visual programming has, for whatever reason, opted to suppress things themselves, we don't want to blindly reset the suppression after a method runs in case it failed to reset it itself.

The UX on that would be this:

 - User sets error suppression to true
 - User runs component which also sets warning suppression to true
 - Component crashes out and does not reach the reset option
 - UI resets suppression, error suppression is now false along with warning suppression
 - User is confused as to why their error suppression isn't working

This could also be the case for methods which don't crash:

 - User sets error suppression to true
 - User runs component which also sets warning suppression to true
 - Component runs happily, and component resets the suppression log as advised in the docs, error and warning suppression are now turned off
 - User is confused as to why their error suppression isn't working

Therefore, the way of doing it in this PR allows for this UX instead:

 - User sets error suppression to true
 - User runs component that does it's thing correctly or not
 - UI resets suppression
 - UI sets suppression to the values the user had set them to before running the method
 - User is not confused because error suppression is still working regardless of what the method did

Now, we can debate whether a user should ever be suppressing their own errors or not as much as we like (and I would gladly welcome it), however, BHoM philosophy is that methods are reflected up at all times, which is the case for suppressing events as well, which means that, regardless of how we feel as to whether users _should_ do that, they _can_ do it and thus we need to support that UX.

Hopefully that all makes sense!

Edit to capture a conversation had with @IsakNaslundBh:

While this works well for the use cases above and the use case captured in #485 , this does now mean the following situation is possible:

 - User tries to set error suppression to true
 - Component finds that error suppression was false at the start, and resets suppression to that after running the component to start suppression

It's a convoluted system however, @IsakNaslundBh and I have both agreed this is an acceptable risk at this time because:

 - Users are unlikely to be trying to suppress events on the UI compared to the risk highlighted in #485 
 - This is a new set of features for this beta so it may be 1 beta with a bit of a problem but the problem has a workaround
 - UX is therefore unchanged - the behaviour this beta around event suppression for a user in visual programming is the same as the 7.0 beta, and we can workshop solutions in the 7.2 milestone