### PR TITLE
Fix target framework in the nuspec file

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.UI.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.UI.nuspec
@@ -15,7 +15,7 @@
     <tags>BHoM interop csharp ui aec</tags>
     <title></title>
     <dependencies>
-      <group targetFramework="netstandard2.0.0">
+      <group targetFramework="netstandard2.0">
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #493 

Fairly straightforward. I simply removed the extra `.0` in the target framework. So this should be pretty quick and easy to review.
