### PR TITLE
Fix Rhino8 Crash With Analytics PopUp

### DIFF
--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -44,12 +44,13 @@ namespace BH.Engine.UI
         /**** Public Methods              ****/
         /*************************************/
 
-        public static void LogUsage(string uiName, string uiVersion, Guid componentId, string callerName, object selectedItem, List<Event> events = null, string fileId = "", string fileName = "")
+        public static void LogUsage(string uiName, string uiVersion, string productVersion, Guid componentId, string callerName, object selectedItem, List<Event> events = null, string fileId = "", string fileName = "")
         {
             TriggerLogUsageArgs args = new TriggerLogUsageArgs()
             {
                 UIName = uiName,
                 UIVersion = uiVersion,
+                ProductVersion = productVersion,
                 ComponentID = componentId,
                 CallerName = callerName,
                 SelectedItem = selectedItem,

--- a/UI_oM/TriggerLogUsageArgs.cs
+++ b/UI_oM/TriggerLogUsageArgs.cs
@@ -36,6 +36,7 @@ namespace BH.oM.UI
         public virtual string CallerName { get; set; } = "";
         public virtual string UIName { get; set; } = "";
         public virtual string UIVersion { get; set; } = "";
+        public virtual string ProductVersion { get; set; } = "";
         public virtual Guid ComponentID { get; set; } = Guid.Empty;
         public virtual string FileID { get; set; } = "";
     }


### PR DESCRIPTION
### Issues addressed by this PR

related to 

![Issue Sorted - GH View](https://github.com/user-attachments/assets/04bb1876-800f-4985-8adf-d1d4137d88c6)

![Issue Sorted - ROBOT View](https://github.com/user-attachments/assets/9a3c8adb-47dd-4b5c-82b0-4be5935fb114)

Preventing the Analytics PopUp Window from popping up, Rhino8 doesn't crash anymore and it's possible to use the BHoM with Rhino8 models. In screenshots above, example of pull from Robot Model in Rhino 8 via the BHoM - all working fine.


### Test files
Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoMAnalytics_Toolkit/%2366-FixRhino8CrashWithAnalyticsPopUp/Test%20Script.gh?csf=1&web=1&e=Ydog48
Robot File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoMAnalytics_Toolkit/%2366-FixRhino8CrashWithAnalyticsPopUp/[TestRobotModel.rtd](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoMAnalytics_Toolkit/%2366-FixRhino8CrashWithAnalyticsPopUp/TestRobotModel.rtd?csf=1&web=1&e=xIGmF5)?csf=1&web=1&e=xIGmF5


### Changelog
- Prevent Analytics Window from popping up