### PR TITLE
Fix issue with versioning log and thread abort

### DIFF
--- a/BHoM_UI/Global/DocumentListener.cs
+++ b/BHoM_UI/Global/DocumentListener.cs
@@ -76,11 +76,14 @@ namespace BH.UI.Base.Global
 
             if (events.Count > 0)
             {
-                if (m_VersioningFormThead != null)
-                    m_VersioningFormThead.Abort();
+                if (m_VersioningForm != null)
+                {
+                    m_VersioningForm.Close();
+                    m_VersioningForm.Dispose();
+                    m_VersioningForm = null;
+                }
 
-                m_VersioningFormThead = new Thread(ShowForm);
-                m_VersioningFormThead.Start(events);
+                ShowForm(events);
             }
         }
 
@@ -88,10 +91,11 @@ namespace BH.UI.Base.Global
 
         public static void OnDocumentClosing(string documentName)
         {
-            if (m_VersioningFormThead != null)
+            if (m_VersioningForm != null)
             {
-                m_VersioningFormThead.Abort();
-                m_VersioningFormThead = null;
+                m_VersioningForm.Close();
+                m_VersioningForm.Dispose();
+                m_VersioningForm = null;
             }
 
             if (!string.IsNullOrEmpty(documentName) && m_OpeningTimes.ContainsKey(documentName))
@@ -115,7 +119,7 @@ namespace BH.UI.Base.Global
             message += "\nPlease review the file before saving it.";
             message += "\n\nHere's the list of components that have been modified:";
 
-            Form form = new Form
+            m_VersioningForm = new Form
             {
                 Text = "BHoM versioning report",
                 AutoSize = true,
@@ -130,7 +134,7 @@ namespace BH.UI.Base.Global
                 FlowDirection = FlowDirection.TopDown,
                 AutoSize = true
             };
-            form.Controls.Add(layout);
+            m_VersioningForm.Controls.Add(layout);
 
             layout.Controls.Add(new Label
             {
@@ -143,7 +147,9 @@ namespace BH.UI.Base.Global
             foreach (VersioningEvent e in events)
                 layout.Controls.Add(GetTable(e));
 
-            form.ShowDialog();
+            m_VersioningForm.Show();
+            m_VersioningForm.Focus();
+            m_VersioningForm.BringToFront();
         }
 
 
@@ -218,7 +224,7 @@ namespace BH.UI.Base.Global
         /*************************************/
 
         private static Dictionary<string, long> m_OpeningTimes = new Dictionary<string, long>();
-        private static Thread m_VersioningFormThead = null;
+        private static Form m_VersioningForm = null;
 
         /*************************************/
     }


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #508 

<!-- Add short description of what has been fixed -->

Fixes an issue with the versioning log window. Previously was handled on a separate thread that was aborted on document close. Thread.Abort() is not supported in later runtimes, see [This link](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.abort?view=net-9.0#system-threading-thread-abort).

This has now been refactored out by instead storing the versioning form in a static varibale, and closing and disposing it at document close and open.

Also changing from ShowDialog to Show and bringing it to top.

### Test files
<!-- Link to test files to validate the proposed changes -->

For grasshopper, this can be tested with files in [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&web=1&e=0c6Dk1&CID=9709424f%2De63b%2D413d%2D9539%2Dbdbd6a77c5bc&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBuroHappoldEngineering%2FModelLaundry%5FToolkit)

Still need to also be tested with Excel as well as Revit.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->