### PR TITLE
Add ProjectId to triggerUseageLogArgs and check if set and update ProjectId

### DIFF
--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -79,6 +79,12 @@ namespace BH.Engine.UI
                         };
 
                         TriggerUsageLog(args);
+                        //Check if the projectID has been set to the args
+                        if (!string.IsNullOrWhiteSpace(args.ProjectID))
+                        {
+                            projectId = args.ProjectID; //Set the project ID
+                            UpdateProjectId(uiName, fileId, projectId); //Ensure the project ID is udpated
+                        }
                     }
                 }
             }

--- a/UI_oM/TriggerLogUsageArgs.cs
+++ b/UI_oM/TriggerLogUsageArgs.cs
@@ -39,6 +39,7 @@ namespace BH.oM.UI
         public virtual Guid ComponentID { get; set; } = Guid.Empty;
         public virtual string FileID { get; set; } = "";
         public virtual string FileName { get; set; } = "";
+        public virtual string ProjectID { get; set; } = null;
     }
 }
 


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->


<!-- Add short description of what has been fixed -->

Add support for retreiving projectId from events fired. If projectId is set upon return from TriggerUseageLog, then Id is used for the current file and set to update and stored for future useage.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->