### PR TITLE
Check if projectId is set on CheckLogOnUiEndOpening and update if it is

### DIFF
--- a/UI_Engine/Compute/LogUsage.cs
+++ b/UI_Engine/Compute/LogUsage.cs
@@ -139,6 +139,12 @@ namespace BH.Engine.UI
                         };
 
                         TriggerUsageLog(args);
+                        //Check if the projectID has been set to the args
+                        if (!string.IsNullOrWhiteSpace(args.ProjectID))
+                        {
+                            projectId = args.ProjectID; //Set the project ID
+                            UpdateProjectId(uiName, fileId, projectId); //Ensure the project ID is udpated
+                        }
                     }
 
                 }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #514

<!-- Add short description of what has been fixed -->

https://github.com/BHoM/BHoM_UI/pull/511 added the ability to check the returned args from the event, and update the project ID if it was changed. When doing this, I missed including the same behaviour for the trigger on UIEndOpening, which is critical for Grasshopper.


### Test files
<!-- Link to test files to validate the proposed changes -->

Run in Grasshopper with project files.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->