### PR TITLE
Fix bug on null outputs for the Explode component

### DIFF
--- a/BHoM_UI/Caller/Run.cs
+++ b/BHoM_UI/Caller/Run.cs
@@ -204,6 +204,20 @@ namespace BH.UI.Base
                     {
                         if (OutputParams[i].IsSelected)
                         {
+                            if (output == null)
+                            {
+                                var subType = OutputParams[i].DataType.UnderlyingType();
+                                Type elementType = subType.Type;
+                                if (QuantitiesAsDouble && typeof(BH.oM.Quantities.IQuantity).IsAssignableFrom(elementType))
+                                    elementType = typeof(double);
+
+                                if (elementType.IsValueType && Nullable.GetUnderlyingType(elementType) == null)
+                                {
+                                    output = Activator.CreateInstance(elementType);
+                                    BH.Engine.Base.Compute.RecordWarning($"Output '{OutputParams[i].Name}' is null but its type ({elementType.Name}) is not nullable. Using default value instead.");
+                                }
+                            }
+
                             m_CompiledSetters[i](m_DataAccessor, output, index);
                             index++;
                         }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #499

See issue for details.

The root of the issue is that the explode component is trying to assign null to a type that is not nullable. In the case of the example script the type is double. This throws an exception that is caught but thrown again so it breaks the outputs for the following outputs of that connector. 


### Test files
You can test with this file:
[ExplodeBug.zip](https://github.com/user-attachments/files/27321030/ExplodeBug.zip)

### Additional comments
**Important!!!** 
You need to recompile Grasshopper after compiling BHoM_UI for the dlls to be copied to the Grasshopper folder in C:\ProgramData\BHoM\GrasshopperPlugin