### PR TITLE
Fix filtering of the wire menu

### DIFF
--- a/BHoM_UI/Global/GlobalSearch.cs
+++ b/BHoM_UI/Global/GlobalSearch.cs
@@ -160,8 +160,12 @@ namespace BH.UI.Base.Global
             if (settings != null)
                 excludedToolkits = settings.Toolkits.Where(x => !x.Include).Select(x => x.Toolkit).ToList();
 
-            if (config != null)
+            if (config?.TypeConstraint != null)
             {
+                Type constraint = config.TypeConstraint;
+                if (constraint != null)
+                    constraint = constraint.UnderlyingType().Type;
+
                 m_SearchMenu.PossibleItems = m_PossibleItems.Where(x =>
                 {
                     if (excludedToolkits.Any(y => x.Text.Contains(y)))
@@ -170,8 +174,13 @@ namespace BH.UI.Base.Global
                     return true; //If the text does not contain any of the excluded toolkits then include it in this display
                 }).Select(x =>
                 {
-                    SearchItem withWeight = x.ShallowClone() as SearchItem;
-                    withWeight.Weight = withWeight.Weight(config);
+                    SearchItem withWeight = x.ShallowClone();
+
+                    if (config.IsReturnType)
+                        withWeight.Weight = withWeight.WeightForInput(constraint.ToText(true));
+                    else
+                        withWeight.Weight = withWeight.WeightForOutput(constraint.OutputKeys());
+
                     return withWeight;
                 }).Where(x => x.Weight > 0).ToList();
             }

--- a/BHoM_UI/Global/Initialisation.cs
+++ b/BHoM_UI/Global/Initialisation.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.Adapter;
+using BH.Engine.Base;
 using BH.Engine.Base.Objects;
 using BH.Engine.Reflection;
 using BH.Engine.UI;
@@ -35,6 +36,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Windows.Media;
 
 
 namespace BH.UI.Base.Global
@@ -415,11 +417,15 @@ namespace BH.UI.Base.Global
 
             // All code elements
             SearchItems.AddRange(codeElements
-                .Select(x => new SearchItem { CallerType = GetCallerType(x.Type), Icon = GetIcon(x.Type), Text = x.DisplayText, Json = x.Json }));
+                .Select(x => new SearchItem { CallerType = GetCallerType(x.Type), Icon = GetIcon(x.Type), Text = x.DisplayText, Json = x.Json, InputKeys = x.InputKeys, OutputKeys = x.OutputKeys }));
 
             // All data libraries
             SearchItems.AddRange(BH.Engine.UI.Query.LibraryItems()
                 .Select(x => new SearchItem { CallerType = typeof(CreateDataCaller), Icon = Properties.Resources.BHoM_Data, Text = x.Replace(Path.DirectorySeparatorChar, '.'), Item = x }));
+
+            // All system types
+            SearchItems.AddRange(BH.Engine.UI.Query.SystemTypes()
+                .Select(x => new SearchItem { CallerType = typeof(CreateTypeCaller), Icon = Properties.Resources.Type, Text = x.ToText(true) }));
 
             stopwatch.Stop();
             BH.Engine.Base.Compute.RecordNote($"Time to create all items for the menu: {stopwatch.Elapsed.TotalMilliseconds / 1000} s.");
@@ -502,7 +508,7 @@ namespace BH.UI.Base.Global
         private static List<SearchItem> GetComponentItems()
         {
             // Reflection is pretty slow on this one so better to just do it manually even if less elegant
-            return new List<SearchItem>
+            List<SearchItem> items = new List<SearchItem>
             {
                 new SearchItem {
                     Item = typeof(RemoveCaller).GetMethod("Remove"),
@@ -589,6 +595,13 @@ namespace BH.UI.Base.Global
                     Text = "BH.oM.CreateDictionary"
                 }
             };
+
+            foreach (SearchItem item in items.Where(x => x.Item is MethodBase))
+                item.InputKeys = ((MethodBase)item.Item).GetParameters()
+                .Select(x => x.ParameterType?.ToText(true))
+                .ToList();
+
+            return items;
         }
 
         /*************************************/

--- a/BHoM_UI/Global/Initialisation.cs
+++ b/BHoM_UI/Global/Initialisation.cs
@@ -425,7 +425,7 @@ namespace BH.UI.Base.Global
 
             // All system types
             SearchItems.AddRange(BH.Engine.UI.Query.SystemTypes()
-                .Select(x => new SearchItem { CallerType = typeof(CreateTypeCaller), Icon = Properties.Resources.Type, Text = x.ToText(true) }));
+                .Select(x => new SearchItem { CallerType = typeof(CreateTypeCaller), Icon = Properties.Resources.Type, Text = x.ToText(true), Item = x }));
 
             stopwatch.Stop();
             BH.Engine.Base.Compute.RecordNote($"Time to create all items for the menu: {stopwatch.Elapsed.TotalMilliseconds / 1000} s.");

--- a/UI_Engine/Convert/CodeElementFromTsv.cs
+++ b/UI_Engine/Convert/CodeElementFromTsv.cs
@@ -63,13 +63,23 @@ namespace BH.Engine.UI
                 return null;
             }
 
+            List<string> inputKeys = new List<string>();
+            List<string> outputKeys = new List<string>();
+            if (parts.Length >= 7)
+            {
+                inputKeys = string.IsNullOrEmpty(parts[5]) ? new List<string>() : parts[5].Split(',').ToList();
+                outputKeys = string.IsNullOrEmpty(parts[6]) ? new List<string>() : parts[6].Split(',').ToList();
+            }
+
             return new CodeElementRecord
             {
                 AssemblyName = parts[0],
                 Type = type,
                 DisplayText = parts[2],
                 Json = parts[3],
-                AssemblyModifiedTime = DateTime.FromFileTimeUtc(utcTime)
+                AssemblyModifiedTime = DateTime.FromFileTimeUtc(utcTime),
+                InputKeys = inputKeys,
+                OutputKeys = outputKeys
             };
 
         }

--- a/UI_Engine/Convert/ToTsv.cs
+++ b/UI_Engine/Convert/ToTsv.cs
@@ -44,7 +44,32 @@ namespace BH.Engine.UI
         [Output("tsv", "Excel row containing the data related to the code element in a tsv format.")]
         public static string ToTsv(this CodeElementRecord codeElement)
         {
-            return $"{codeElement.AssemblyName}\t{codeElement.Type}\t{codeElement.DisplayText}\t{codeElement.Json}\t{codeElement.AssemblyModifiedTime.ToFileTimeUtc()}";
+            return $"{codeElement.AssemblyName}" +
+                $"\t{codeElement.Type}" +
+                $"\t{codeElement.DisplayText}" +
+                $"\t{codeElement.Json}" +
+                $"\t{codeElement.AssemblyModifiedTime.ToFileTimeUtc()}" +
+                $"\t{ToCommaSeparatedList(codeElement.InputKeys)}" +
+                $"\t{ToCommaSeparatedList(codeElement.OutputKeys)}";
+        }
+
+
+        /*************************************/
+        /**** Private Methods             ****/
+        /*************************************/
+
+        private static string ToCommaSeparatedList(List<string> keys)
+        {
+            switch (keys?.Count)
+            {
+                case 0:
+                case null:
+                    return "";
+                case 1:
+                    return keys.First();
+                default: 
+                    return keys.Aggregate((a, b) => a + "," + b);
+            }
         }
 
         /*************************************/

--- a/UI_Engine/Query/CodeElements.cs
+++ b/UI_Engine/Query/CodeElements.cs
@@ -50,30 +50,34 @@ namespace BH.Engine.UI
         {
             List<CodeElementRecord> items = new List<CodeElementRecord>();
 
-            // All adapter constructors
-            items.AddRange(BH.Engine.UI.Query.AdapterConstructorItems()
-                .Select(x => new CodeElementRecord { AssemblyName = AssemblyName(x), AssemblyModifiedTime = AssemblyModifiedTime(x), Type = CodeElementType.AdapterConstructor, DisplayText = x.ToText(true), Json = x.ToJson() }));
+            /// Types
 
             // All constructable BHoM objects and requests
             items.AddRange(BH.Engine.UI.Query.ConstructableTypeItems()
-                .Select(x => new CodeElementRecord { AssemblyName = AssemblyName(x), AssemblyModifiedTime = AssemblyModifiedTime(x), Type = GetConstructableType(x), DisplayText = x.ConstructorText(), Json = x.ToJson() }));
+                .Select(x => CodeElement(x, GetConstructableType(x), x.ConstructorText())));
 
             // All Enums
             items.AddRange(BH.Engine.UI.Query.EnumItems()
-                .Select(x => new CodeElementRecord { AssemblyName = AssemblyName(x), AssemblyModifiedTime = AssemblyModifiedTime(x), Type = CodeElementType.Enum, DisplayText = x.ToText(true), Json = x.ToJson() }));
+                .Select(x => CodeElement(x, CodeElementType.Enum, x.ToText(true))));
+
+            // All Types
+            items.AddRange(BH.Engine.UI.Query.TypeItems()
+                .Select(x => CodeElement(x, CodeElementType.Type, x.ToText(true))));
+
+            /// Methods
+
+            // All adapter constructors
+            items.AddRange(BH.Engine.UI.Query.AdapterConstructorItems()
+                .Select(x => CodeElement(x, CodeElementType.AdapterConstructor, x.ToText(true))));
 
             // All methods for the BHoM Engine (including creators)
             items.AddRange(BH.Engine.Base.Query.BHoMMethodList()
                         .Where(x => x.IsExposed())
-                        .Select(x => new CodeElementRecord { AssemblyName = AssemblyName(x), AssemblyModifiedTime = AssemblyModifiedTime(x), Type = GetMethodType(x), DisplayText = x.ToText(includePath: true, removeIForInterface: false), Json = x.ToJson() }));
+                        .Select(x => CodeElement(x, GetMethodType(x), x.ToText(includePath: true, removeIForInterface: false))));
 
             // All methods from external class
             items.AddRange(BH.Engine.UI.Query.ExternalItems()
-                .Select(x => new CodeElementRecord { AssemblyName = AssemblyName(x), AssemblyModifiedTime = AssemblyModifiedTime(x), Type = CodeElementType.Method_External, DisplayText = x.ToText(true), Json = x.ToJson() }));
-
-            // All Types
-            items.AddRange(BH.Engine.UI.Query.TypeItems()
-                .Select(x => new CodeElementRecord { AssemblyName = AssemblyName(x), AssemblyModifiedTime = AssemblyModifiedTime(x), Type = CodeElementType.Type, DisplayText = x.ToText(true), Json = x.ToJson() }));
+                .Select(x => CodeElement(x, CodeElementType.Method_External, x.ToText(true))));
 
             // Return the list
             return items;
@@ -82,6 +86,51 @@ namespace BH.Engine.UI
 
         /*************************************/
         /**** Public Methods              ****/
+        /*************************************/
+
+        private static CodeElementRecord CodeElement(Type type, CodeElementType elementType, string displayText)
+        {
+            List<Type> inputTypes = type.GetProperties()
+                .Select(x => x.PropertyType?.UnderlyingType()?.Type)
+                .Where(x => x != null)
+                .Distinct()
+                .ToList();
+
+            return new CodeElementRecord
+            {
+                AssemblyName = AssemblyName(type),
+                AssemblyModifiedTime = AssemblyModifiedTime(type),
+                Type = elementType,
+                DisplayText = displayText,
+                Json = type.ToJson(),
+                InputKeys = inputTypes.Select(x => x.ToText(true)).ToList(),
+                OutputKeys = type.UnderlyingType()?.Type.OutputKeys()
+            };
+        }
+
+        /*************************************/
+
+        private static CodeElementRecord CodeElement(MethodBase method, CodeElementType elementType, string displayText)
+        {
+            Type outputType = (method is MethodInfo) ? ((MethodInfo)method).ReturnType : method.DeclaringType;
+            List<Type> inputTypes = method.GetParameters()
+                .Select(x => x.ParameterType?.UnderlyingType()?.Type)
+                .Where(x => x != null)
+                .Distinct()
+                .ToList();
+
+            return new CodeElementRecord
+            {
+                AssemblyName = AssemblyName(method),
+                AssemblyModifiedTime = AssemblyModifiedTime(method),
+                Type = elementType,
+                DisplayText = displayText,
+                Json = method.ToJson(),
+                InputKeys = inputTypes.Select(x => x.ToText(true)).ToList(),
+                OutputKeys = outputType.UnderlyingType()?.Type.OutputKeys()
+            };
+        }
+
         /*************************************/
 
         private static string AssemblyName(MethodBase method)

--- a/UI_Engine/Query/Items.cs
+++ b/UI_Engine/Query/Items.cs
@@ -139,12 +139,21 @@ namespace BH.Engine.UI
         {
             return Engine.Base.Query.AllTypeList()
                 .Where(x => x.Namespace.StartsWith("BH."))
-                .Concat(new List<Type> { typeof(Type), typeof(Enum),
+                .Concat(SystemTypes())
+                .Where(x => !x.IsNotImplemented() && !x.IsDeprecated());
+        }
+
+        /***************************************************/
+
+        [Description("Extracts all basic system types.")]
+        [Output("items", "All basic system types.")]
+        public static IEnumerable<Type> SystemTypes()
+        {
+            return new List<Type> { typeof(Type), typeof(Enum),
                     typeof(object), typeof(bool), typeof(byte),
                     typeof(char), typeof(string),
                     typeof(float), typeof(double), typeof(decimal), typeof(short), typeof(int), typeof(long),
-                    typeof(DateTime)})
-                .Where(x => !x.IsNotImplemented() && !x.IsDeprecated());
+                    typeof(DateTime)};
         }
 
         /***************************************************/

--- a/UI_Engine/Query/OutputKeys.cs
+++ b/UI_Engine/Query/OutputKeys.cs
@@ -20,40 +20,51 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Base;
+using BH.Engine.Base;
+using BH.Engine.Reflection;
+using BH.oM.Base.Attributes;
+using BH.oM.UI;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.UI
+namespace BH.Engine.UI
 {
-    public class SearchItem : BHoMObject
+    public static partial class Query
     {
-        /***************************************************/
-        /**** Properties                                ****/
-        /***************************************************/
+        /*************************************/
+        /**** Public Methods              ****/
+        /*************************************/
 
-        public virtual Type CallerType { get; set; } = null;
+        [Description("Gets all the text representations of types that accept the provided type as input.")]
+        [Input("type", "The type to get the output key from.")]
+        [Output("Keys", "Text representations of types that accept the provided type as input.")]
+        public static List<string> OutputKeys(this Type type)
+        {
+            if (m_OutputTypeKeys.ContainsKey(type))
+                return m_OutputTypeKeys[type];
+            else
+            {
+                List<string> keys = new List<Type> { type }
+                    .Concat(type.BaseTypes().Where(x => x.Namespace?.StartsWith("BH.") == true))
+                    .Select(x => x.ToText(true))
+                    .ToList();
 
-        public virtual object Item { get; set; } = null;
+                m_OutputTypeKeys[type] = keys;
+                return keys;
+            }
+        }
 
-        public virtual Bitmap Icon { get; set; } = null;
+        /*************************************/
+        /**** Private Fields              ****/
+        /*************************************/
 
-        public virtual string Text { get; set; } = "";
+        private static Dictionary<Type, List<string>> m_OutputTypeKeys = new Dictionary<Type, List<string>>();
 
-        public virtual double Weight { get; set; } = 1.0;
-
-        public virtual string Json { get; set; } = "";
-
-        public virtual List<string> InputKeys { get; set; } = new List<string>();
-
-        public virtual List<string> OutputKeys { get; set; } = new List<string>();
-
-
-        /***************************************************/
+        /*************************************/
     }
 }
 

--- a/UI_Engine/Query/Weight.cs
+++ b/UI_Engine/Query/Weight.cs
@@ -116,83 +116,56 @@ namespace BH.Engine.UI
             Type constraint = config.TypeConstraint;
             if (constraint != null)
                 constraint = constraint.UnderlyingType().Type;
-            bool isReturnType = config.IsReturnType;
 
-            if (isReturnType)
-            {
-                object target = item.Item;
-                Type returnType = typeof(object);
-
-                if (target is MethodInfo)
-                    returnType = ((MethodInfo)target).ReturnType;
-                else if (target is ConstructorInfo)
-                    returnType = ((ConstructorInfo)target).DeclaringType;
-                else if (target is Type)
-                {
-                    if (item.CallerType.Name == "CreateTypeCaller")
-                        returnType = typeof(Type);
-                    else
-                        returnType = target as Type;
-                }
-                else if (target is CustomItem)
-                {
-                    CustomItem ci = target as CustomItem;
-                    List<Type> types = ci.OutputTypes.Where(x => x != null).ToList();
-
-                    double weight = 0;
-                    if (types.Count > 0)
-                        weight = types.Max(x => DistanceWeight(constraint, x.UnderlyingType().Type));
-
-                    if (ci.Tags.Count > 0 && config.Tags.Count > 0)
-                        weight *= 1 + ci.Tags.Intersect(config.Tags).Count();
-
-                    return weight;
-                }
-
-                double callerWeight = item.Text.StartsWith("BH.oM") ? 1.0 : 0.1;
-                return callerWeight * DistanceWeight(returnType.UnderlyingType().Type, constraint);
-            }
+            if (config.IsReturnType)
+                return WeightForInput(item, constraint.ToText(true));
             else
+                return WeightForOutput(item, constraint.OutputKeys());
+        }
+
+        /*************************************/
+
+        public static double WeightForInput(this SearchItem item, string validKey)
+        {
+            // handles the case for types separately
+            if (validKey == "System.Type")
+                return item.CallerType?.Name == "CreateTypeCaller" ? 1.0 : 0;
+            else if (item.CallerType?.Name == "CreateTypeCaller")
+                return 0;
+
+            if (item.OutputKeys.Count == 0)
+                return 0;
+            else if (item.OutputKeys[0] == validKey)
             {
-                object target = item.Item;
-
-                if (target is MethodBase)
+                switch (item.CallerType.Name)
                 {
-                    ParameterInfo[] parameters = ((MethodBase)target).GetParameters();
-                    if (parameters.Length == 0)
-                        return 0;
-                    else
-                        return parameters.Max(x => DistanceWeight(constraint, x.ParameterType.UnderlyingType().Type));
+                    case "CreateAdapterCaller":
+                    case "CreateObjectCaller":
+                    case "CreateRequestCaller":
+                    case "CreateEnumCaller":
+                        return 1.0;
+                    default:
+                        return 0.9;
                 }
-                else if (target is Type)
-                {
-                    if (item.CallerType.Name == "CreateTypeCaller")
-                        return constraint == typeof(Type) ? 1 : 0;
-                    else
-                    {
-                        PropertyInfo[] properties = ((Type)target).GetProperties();
-                        if (properties.Length == 0)
-                            return 0;
-                        else
-                            return properties.Max(x => DistanceWeight(constraint, x.TryGetPropertyType().UnderlyingType().Type));
-                    }    
-                }
-                else if (target is CustomItem)
-                {
-                    CustomItem ci = target as CustomItem;
-                    List<Type> types = ci.InputTypes.Where(x => x != null).ToList();
-                    double weight = 0;
-                    if (types.Count > 0)
-                        weight = types.Max(x => DistanceWeight(constraint, x.UnderlyingType().Type));
-
-                    if (ci.Tags.Count > 0 && config.Tags.Count > 0)
-                        weight *= 1 + ci.Tags.Intersect(config.Tags).Count();
-
-                    return weight;
-                }
-                else
-                    return 0;
             }
+            else if (item.OutputKeys.Any(x => x == validKey))
+                return 0.75;
+            else 
+                return 0;
+        }
+
+        /*************************************/
+
+        public static double WeightForOutput(this SearchItem item, List<string> validKeys)
+        {
+            if (validKeys == null || validKeys.Count == 0 || item.CallerType?.Name == "CreateTypeCaller")
+                return 0;
+            else if (item.InputKeys.Contains(validKeys[0]))
+                return 1.0;
+            else if (item.InputKeys.Intersect(validKeys).Any())
+                return 0.75;
+            else 
+                return 0;
         }
 
 

--- a/UI_oM/CodeElementRecord.cs
+++ b/UI_oM/CodeElementRecord.cs
@@ -45,6 +45,10 @@ namespace BH.oM.UI
 
         public virtual string Json { get; set; } = "";
 
+        public virtual List<string> InputKeys {get; set; } = new List<string>();
+
+        public virtual List<string> OutputKeys { get; set; } = new List<string>();
+
 
         /***************************************************/
     }


### PR DESCRIPTION
### Issues addressed by this PR

Closes #547

As described in the issue, the wire menu (created when dragging from a component connector in GH) was not provided useful element most of the time. This was due to to a change in our assembly loading strategy. Since the assemblies are now loaded dynamically, all the information needed to properly populate that menu was not available anymore. 

The strategy to solve has been to add two additional columns in the AssemblyContent.tsv file with the information necessary to due that filtering correctly (i.e. providing input and output types of each component alongside their base types and interfaces).

### Test files
Play with the wire menu as much as you can on different components, different types of expected inputs and outputs and make sure that the suggestions from the wire menu are making sense. Don't hesitate to comment if the order of those suggestions also seems off to you. 

**Important**: 
 - Make sure to recompile Grasshopper after compiling the BHoM_UI otherwise you will not see the effect in GH.
 - make sure to delete the AssemblyContent file in C:\ProgramData\BHoM\Resources. We need to generate a new one for those additional columns to be created. This is only a problem for testers compiling the code themselves, the installer would clean the file anyways. 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->