### PR TITLE
Add ability to create custom UI ribbons via settings

### DIFF
--- a/BHoM_UI/BHoM_UI.csproj
+++ b/BHoM_UI/BHoM_UI.csproj
@@ -10,12 +10,7 @@
 		<RootNamespace>BH.UI</RootNamespace>
 		<FileVersion>9.2.0.0</FileVersion>
 		<OutputPath>..\Build\</OutputPath>
-		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\UI_Engine\UI_Engine.csproj" />

--- a/BHoM_UI/Global/Initialisation.cs
+++ b/BHoM_UI/Global/Initialisation.cs
@@ -44,6 +44,13 @@ namespace BH.UI.Base.Global
     public static class Initialisation
     {
         /*************************************/
+        /**** Events                      ****/
+        /*************************************/
+
+        public static event EventHandler<CustomRibbonEntry> CustomRibbonEntryLoaded;
+
+
+        /*************************************/
         /**** Public Properties           ****/
         /*************************************/
 
@@ -56,6 +63,8 @@ namespace BH.UI.Base.Global
         public static List<SearchItem> SearchItems { get; set; } = new List<SearchItem>();
 
         public static string AssemblyContentFilePath { get; set; } = Path.Combine(BH.Engine.Base.Query.BHoMFolderResources(), "AssemblyContent.tsv");
+
+        public static List<CustomRibbonEntry> CustomRibbonEntries { get; set; } = new List<CustomRibbonEntry>();
 
 
         /*************************************/
@@ -94,10 +103,11 @@ namespace BH.UI.Base.Global
             BH.Engine.Settings.Compute.LoadSettings(directory);
             BH.Engine.Settings.Compute.LoadSettings(directory, "*.cfg"); //Legacy cfg files to be loaded in
 
-            List<ISettings> allSettings = BH.Engine.Settings.Query.GetAllSettings();
-            List<IInitialisationSettings> initialisationSettings = allSettings.OfType<IInitialisationSettings>().ToList();
-
             bool success = true;
+            List<ISettings> allSettings = BH.Engine.Settings.Query.GetAllSettings();
+
+            // Loading intialisation settings
+            List<IInitialisationSettings> initialisationSettings = allSettings.OfType<IInitialisationSettings>().ToList();
             foreach(var settings in initialisationSettings)
             {
                 try
@@ -110,12 +120,34 @@ namespace BH.UI.Base.Global
                 }
             }
 
+            // Loading custom ribbon items
+            List<CustomRibbonSettings> ribbonSettings = allSettings.OfType<CustomRibbonSettings>().ToList();
+            foreach (var settings in ribbonSettings)
+            {
+                foreach (var entry in settings.Entries)
+                {
+                    try
+                    {
+                        CustomRibbonEntryLoaded?.Invoke(null, entry);
+                        CustomRibbonEntries.Add(entry);
+                    }
+                    catch (Exception e)
+                    {
+                        BH.Engine.Base.Compute.RecordWarning(e, $"Failed to load custom entry for ribbon. Tab name: {entry.TabName}, Category: {entry.Category}, json: {entry.ItemJson}.");
+                    }
+                }
+                
+            }
+
             stopwatch.Stop();
             BH.Engine.Base.Compute.RecordNote($"Time to load toolkit settings: {stopwatch.Elapsed.TotalMilliseconds / 1000} s");
 
             return success;
         }
 
+
+        /*************************************/
+        /**** Private Methods             ****/
         /*************************************/
 
         private static bool InitialiseToolkit(IInitialisationSettings settings)

--- a/BHoM_Windows_UI/BHoM_Windows_UI.csproj
+++ b/BHoM_Windows_UI/BHoM_Windows_UI.csproj
@@ -10,13 +10,8 @@
 		<RootNamespace>BH.UI.Base.Windows</RootNamespace>
 		<FileVersion>9.2.0.0</FileVersion>
 		<OutputPath>..\Build\</OutputPath>
-		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 		<UseWPF>true</UseWPF>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
-	</ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\UI_oM\UI_oM.csproj" />

--- a/UI_oM/CustomRibbonEntry.cs
+++ b/UI_oM/CustomRibbonEntry.cs
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.UI
+{
+    public class CustomRibbonEntry : IObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual Type CallerType { get; set; } = null;
+
+        public virtual string ItemJson { get; set; } = "";
+
+        public virtual Bitmap Icon { get; set; } = null;
+
+        public virtual string TabName { get; set; } = "";
+
+        public virtual string Category { get; set; } = "";
+
+        public virtual int GroupIndex { get; set; } = 1;
+
+        /***************************************************/
+    }
+}
+
+
+
+
+
+

--- a/UI_oM/CustomRibbonSettings.cs
+++ b/UI_oM/CustomRibbonSettings.cs
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.UI
+{
+    public class CustomRibbonSettings : ISettings
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual string Name { get; set; } = "";
+
+        public virtual List<CustomRibbonEntry> Entries { get; set; } = new List<CustomRibbonEntry>();
+
+
+        /***************************************************/
+    }
+}
+
+
+
+
+
+


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/3589

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #536 

This allows the users to create their own custom UI ribbons using a BHoM settings file. Here's an example accross our 3 supported UIs:
<img width="1277" height="807" alt="image (3)" src="https://github.com/user-attachments/assets/2b928421-7a9c-4296-b5b6-1db47a4aabae" />

<img width="1421" height="365" alt="image (2)" src="https://github.com/user-attachments/assets/fa9c8c75-04bc-4ea9-b8b3-5da951496c16" />


### Test files
 - You can either test this using the settings file I already created (copy it to `C:\ProgramData\BHoM\Settings`): 
[StructureRibbon.json](https://github.com/user-attachments/files/28435681/StructureRibbon.json)
 - Or you can create you own custom ribbon using this GH script: 
[CreateRibbonSettings.zip](https://github.com/user-attachments/files/28435874/CreateRibbonSettings.zip)



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->