### PR TITLE
Fix menu filtering bug

### DIFF
--- a/BHoM_UI/Global/GlobalSearch.cs
+++ b/BHoM_UI/Global/GlobalSearch.cs
@@ -155,7 +155,7 @@ namespace BH.UI.Base.Global
         /*************************************/
 
         private static void ShowWithConstraint(SearchConfig config)
-        {               
+        {
             // Apply weight base on type constraint
             if (config?.TypeConstraint != null)
             {
@@ -175,6 +175,8 @@ namespace BH.UI.Base.Global
                     return withWeight;
                 }).Where(x => x.Weight > 0).ToList();
             }
+            else
+                m_SearchMenu.PossibleItems = m_PossibleItems.ToList();
 
             m_SearchMenu.HitsOnEmptySearch = config != null;
             m_SearchMenu.ShowResults("");


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #558 

The menu filtering was not resetting correctly after using a wire menu, effectively limiting the available items on following menu searches. This PR fixes that. 


### Test files
Follow the same procedure as detailed in the issue and make sure this is resolved.
<img width="1909" height="979" alt="Image" src="https://github.com/user-attachments/assets/0b77c13d-d7df-4a04-a519-98185d97e6d4" />


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
**!!Important!!**: Make sure to also compile Grasshopper_UI after compiling BHoM_UI before testing.